### PR TITLE
Changes made to using item

### DIFF
--- a/client/items.lua
+++ b/client/items.lua
@@ -1,42 +1,37 @@
-AddEventHandler('linden_inventory:burger', function(item, wait, cb)
-	cb(true)
-	Citizen.Wait(wait)
+AddEventHandler('linden_inventory:burger', function(item)
 	TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You ate a delicious burger', length = 2500})
 end)
 
-AddEventHandler('linden_inventory:water', function(item, wait, cb)
-	cb(true)
-	Citizen.Wait(wait)
+AddEventHandler('linden_inventory:water', function(item)
 	TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You drank some refreshing water', length = 2500})
 end)
 
-AddEventHandler('linden_inventory:cola', function(item, wait, cb)
-	cb(true)
-	Citizen.Wait(wait)
+AddEventHandler('linden_inventory:cola', function(item)
 	TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You drank some delicious eCola', length = 2500})
 end)
 
-AddEventHandler('linden_inventory:mustard', function(item, wait, cb)
-	cb(true)
-	Citizen.Wait(wait)
+AddEventHandler('linden_inventory:mustard', function(item)
 	TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You.. drank mustard', length = 2500})
 end)
 
-AddEventHandler('linden_inventory:bandage', function(item, wait, cb)
+AddEventHandler('linden_inventory:bandageCheck', function(item, cb)
 	local maxHealth = 200
 	local health = GetEntityHealth(ESX.PlayerData.ped)
-	if health < maxHealth then
-		cb(true)
-		Citizen.Wait(wait)
-		local newHealth = math.min(maxHealth, math.floor(health + maxHealth / 16))
-		SetEntityHealth(ESX.PlayerData.ped, newHealth)
-		TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You feel better already', length = 2500})
+
+	if health < maxHealth then cb(true)
 	else cb(false) end
 end)
 
-AddEventHandler('linden_inventory:armour', function(item, wait, cb)
-	cb(true)
-	Citizen.Wait(wait)
+AddEventHandler('linden_inventory:bandage', function(item)
+	local maxHealth = 200
+	local health = GetEntityHealth(ESX.PlayerData.ped)
+	local newHealth = math.min(maxHealth, math.floor(health + maxHealth / 16))
+
+	SetEntityHealth(ESX.PlayerData.ped, newHealth)
+	TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = 'You feel better already', length = 2500})
+end)
+
+AddEventHandler('linden_inventory:armour', function(item)
 	SetPlayerMaxArmour(playerID, 100)
 	SetPedArmour(ESX.PlayerData.ped, 100)
 end)

--- a/shared/items.lua
+++ b/shared/items.lua
@@ -173,6 +173,9 @@ Config.ItemList = {
 		coords = { x = -0.14, y = 0.02, z = -0.08 },
 		rotation = { x = -50.0, y = -50.0, z = 0.0 },
 		useTime = 2500,
+		canCancel = true,
+		itemLabel = 'This is a Bandage dickhead',
+		eventCheck = 'linden_inventory:bandageCheck',
 		event = 'linden_inventory:bandage',
 	},
 


### PR DESCRIPTION
As discussed in Discord, changed use item functionality to allow for checks before using item if required and the ability to abort using the item if accidentally hit on hotbar for example. Feel free to change this up how you see fit however using items like this allows more flexibility when using the inventory. Also a couple of small QOL stuff with Progbar.

Changes:
- Modified to have a check event prior to progbar triggering. If the item doesnt have or need an event check (burger for example), it just proceeds to trigger progbar with no check.
- Modified to trigger event after progbar is complete
- Modified progbar to allow more customization (labels, ability to cancel).

Example used with Bandage as I did not want to create an item you didn't already have. Event 'bandageCheck' checks if the players heal is not max (200 HP). If it isn't, callback true and proceeds with progbar which has the ability to cancel if accidentally used. Once progbar is completed, it triggers to bandage event to heal the player.