### PR TITLE
add an export for cancelled so value can be read in other scripts

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,7 +1,7 @@
 local Blips, Drops, Usables, weaponTimer, currentDrop, currentWeapon = {}, {}, {}, 0
 cancelled = false
 
-exports('itemCancelled', function()
+exports('ItemCancelled', function()
 	return cancelled
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,6 +1,10 @@
 local Blips, Drops, Usables, weaponTimer, currentDrop, currentWeapon = {}, {}, {}, 0
 cancelled = false
 
+exports('itemCancelled', function()
+	return cancelled
+end)
+
 ClearWeapons = function()
 	for k, v in pairs(Weapons) do
 		SetPedAmmo(ESX.PlayerData.ped, v.hash, 0)


### PR DESCRIPTION
In our server, we define the events for our items in separate scripts outside of `linden_inventory`.

With the new functionality that allows cancellation of item usage, we need to be able to access the status of `cancelled` in our other scripts to make use of this new functionality. Adding this export allows us to retrieve the value of `cancelled` from an external script, and allows us to continue to define our item events in external scripts via something like:

```
RegisterNetEvent('foo:bar')
AddEventHandler('foo:bar', function(item, wait, cb)
    cb(true)
    SetTimeout(wait, function()
        if not exports["linden_inventory"]:itemCancelled() then
            print('do something')
        end
    end)
end)
```