### PR TITLE
bt-target Support for Shops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -147,6 +147,41 @@ AddEventHandler('targetPlayerAnim', function()
 	ClearPedSecondaryTask(ESX.PlayerData.ped)
 end)
 
+Citizen.CreateThread(function()
+	for i = 1, #Config.Shops, 1 do
+		if (Config.Shops[i].type ~= nil and Config.bt_target) then
+			local jobAccess = {"all"}
+			if (Config.Shops[i].job ~= nil) then jobAccess = { Config.Shops[i].job } end
+			local length, width = 0.5, 0.5
+			if (Config.Shops[i].length ~= nil) then length = Config.Shops[i].bt_length end
+			if (Config.Shops[i].width ~= nil) then width = Config.Shops[i].bt_width end
+
+			exports['bt-target']:AddBoxZone(Config.Shops[i].type['name'], Config.Shops[i].coords, length, width, {
+				name=Config.Shops[i].type['name'],
+				heading=90,
+				debugPoly=false,
+				minZ=29.8,
+				maxZ=32.0
+			}, {
+				options = {
+					{
+						event = "OpenShopTarget",
+						icon = "fas fa-shopping-basket",
+						label = "Open " .. Config.Shops[i].type['name'],
+						shopid = i,
+					},
+				},
+				job = jobAccess,
+				distance = 6.0
+			})
+		end
+   end
+end)
+RegisterNetEvent('OpenShopTarget')
+AddEventHandler('OpenShopTarget',function(data)
+    OpenShop(data.shopid)
+end)
+
 OpenShop = function(id)
 	if not currentInventory and CanOpenInventory() and not CanOpenTarget(ESX.PlayerData.ped) then
 		if closestShop and GetInvokingResource() ~= Config.Resource then id = closestShop end
@@ -585,7 +620,7 @@ TriggerLoops = function()
 			if IsPedInAnyVehicle(ESX.PlayerData.ped, false) then SetPedCanSwitchWeapon(ESX.PlayerData.ped, true) else SetPedCanSwitchWeapon(ESX.PlayerData.ped, false) end
 			playerCoords = GetEntityCoords(ESX.PlayerData.ped)
 			if not invOpen then
-				if not id or type == 'shop' then
+				if not id or (type == 'shop' and not Config.bt_target) then
 					if id then
 						sleep = 5
 						closestShop = id

--- a/config.lua
+++ b/config.lua
@@ -35,3 +35,6 @@ Config.AutoReload = false
 
 -- Randomise the price of items in each shop at resource start
 Config.RandomPrices = false
+
+-- If you use bt-target and want to make use of bt-target on the shops enable this.
+Config.bt_target = true

--- a/shared/shops.lua
+++ b/shared/shops.lua
@@ -152,8 +152,8 @@ Config.Shops = {
 	{ coords = vector3(-2544.092, 2316.184, 33.2), name = 'RON'},
 
 	
-	{ type = Config.PoliceArmoury, job = 'police', coords = vector3(487.235, -997.108, 30.69) },
-	{ type = Config.Medicine, job = 'ambulance', coords = vector3(306.3687, -601.5139, 43.28406) },
+	{ type = Config.PoliceArmoury, job = 'police', coords = vector3(487.235, -997.108, 30.69), bt_length = 0.5, bt_width = 3.0 },
+	{ type = Config.Medicine, job = 'ambulance', coords = vector3(306.3687, -601.5139, 43.28406) --[[, bt_length = 0.5, bt_width = 3.0]] },
 
 	{ type = Config.BlackMarketArms, coords = vector3(309.09, -913.75, 56.46), currency = 'black_money' },
 }


### PR DESCRIPTION
Not sure if this is something you wan't to implement into the core code. But this is a good base for implementing bt-target directly into the inventory (since people seem to like doing that).

**Added:**
- Config for enabling / disabling.
- Width / Length of bt-target in shops.lua
- Opening of shop through bt-target in client/main.lua