### PR TITLE
feat+fixes: Refresh item data as it moves; weapon-related fixes; other

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -118,7 +118,7 @@ StartInventory = function()
 			end
 			for k, v in pairs(Config.Shops) do
 				if not v.type then v.type = Config.General end
-				if v.type and v.type.blip and (not v.job or v.job == ESX.PlayerData.job.name) and (not v.grade or v.grade <= ESX.PlayerData.job.grade) then
+				if v.type and v.type.blip and (not v.job or v.job == ESX.PlayerData.job.name) then
 					local data = v.type
 					Blips[k] = AddBlipForCoord(v.coords.x, v.coords.y, v.coords.z)
 					SetBlipSprite(Blips[k], data.blip.id)
@@ -744,7 +744,6 @@ TriggerLoops = function()
 		local text, type, id = ''
 		while ESX.PlayerLoaded do
 			local sleep = 250
-			if IsPedInAnyVehicle(ESX.PlayerData.ped, false) then SetPedCanSwitchWeapon(ESX.PlayerData.ped, true) else SetPedCanSwitchWeapon(ESX.PlayerData.ped, false) end
 			if not invOpen then
 				playerCoords = GetEntityCoords(ESX.PlayerData.ped)
 				if not Config.bt_target and not id or type == 'shop' then
@@ -753,13 +752,12 @@ TriggerLoops = function()
 						closestShop = id
 						DrawMarker(2, Config.Shops[id].coords.x,Config.Shops[id].coords.y,Config.Shops[id].coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, false, true, false, false, false)			
 						local distance = #(playerCoords - Config.Shops[id].coords)
-						local RenderDist =  Config.Shops[id].RenderDist or 4
 						local name = Config.Shops[id].name or Config.Shops[id].type.name
 						if distance <= 1 then text='[~g~E~s~] '..name
 							if IsControlJustPressed(0, 38) then
 								OpenShop(id)
 							end
-						elseif distance > RenderDist then id, type = nil, nil
+						elseif distance > Config.Shops[id].distance or 4 then id, type = nil, nil
 						else text = Config.Shops[id].name or Config.Shops[id].type.name end
 						if distance <= 2 then DrawText3D(Config.Shops[id].coords, text) end
 					else
@@ -767,8 +765,7 @@ TriggerLoops = function()
 						for k, v in pairs(Config.Shops) do
 							if not id and v.coords and (not v.job or v.job == ESX.PlayerData.job.name) and (not v.grade or v.grade <= ESX.PlayerData.job.grade) then
 								local distance = #(playerCoords - v.coords)
-								local RenderDist =  v.RenderDist or 4
-								if distance <= RenderDist then
+								if distance <= v.distance or 4 then
 									sleep = 10
 									id = k
 									type = 'shop'
@@ -782,20 +779,18 @@ TriggerLoops = function()
 						sleep = 5
 						DrawMarker(2, Config.Stashes[id].coords.x,Config.Stashes[id].coords.y,Config.Stashes[id].coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 30, 150, 222, false, false, false, true, false, false, false)			
 						local distance = #(playerCoords - Config.Stashes[id].coords)
-						local RenderDist =  Config.Stashes[id].RenderDist or 4
 						if distance <= 1 then text='[~g~E~s~] '..Config.Stashes[id].name
 							if IsControlJustPressed(0, 38) then
 								OpenStash(Config.Stashes[id])
 							end
-						elseif distance > RenderDist then id, type = nil, nil
+						elseif distance > Config.Stashes[id].distance or 4 then id, type = nil, nil
 						else text = Config.Stashes[id].name end
 						if distance <= 2 then DrawText3D(Config.Stashes[id].coords, text) end
 					else
 						for k, v in pairs(Config.Stashes) do
 							if not id and v.coords and (not v.job or v.job == ESX.PlayerData.job.name) and (not v.grade or v.grade <= ESX.PlayerData.job.grade) then
 								local distance = #(playerCoords - v.coords)
-								local RenderDist =  v.RenderDist or 4
-								if distance <= RenderDist then
+								if distance <= v.distance or 4 then
 									sleep = 10
 									id = k
 									type = 'stash'

--- a/server/main.lua
+++ b/server/main.lua
@@ -442,12 +442,8 @@ AddEventHandler('linden_inventory:buyItem', function(info)
 				currency = 'Money'
 				money = getInventoryItem(xPlayer, item.name).count
 			end
-		elseif shopCurrency == 'money' then
+		elseif shopCurrency == 'money' or shopCurrency == 'black_money' then
 			item.name = 'money'
-			currency = Items[item.name].label
-			money = getInventoryItem(xPlayer, item.name).count
-		elseif shopCurrency == 'black_money' then
-			item.name = 'black_money'
 			currency = Items[item.name].label
 			money = getInventoryItem(xPlayer, item.name).count
 		else
@@ -455,7 +451,7 @@ AddEventHandler('linden_inventory:buyItem', function(info)
 			currency = item.label
 			money = getInventoryItem(xPlayer, shopCurrency.name).count
 		end
-			
+
 		if checkShop.name ~= data.name then
 			TriggerBanEvent(xPlayer, 'tried to buy '..data.name..' but slot contains '..checkShop.name)
 		elseif (checkShop.price * count) ~= data.price then
@@ -494,14 +490,9 @@ AddEventHandler('linden_inventory:buyItem', function(info)
 						if Config.Logs then CreateLog(xPlayer.source, false, ('bought %sx %s from %s for %s'):format(ESX.Math.GroupDigits(count), data.label, shopName, cost), 'shop') end
 					end
 				else
-					local missing
-					if currency == 'bank' or item.name == 'money' then
-						missing = '$'..ESX.Math.GroupDigits(ESX.Round(data.price - money)).. ' '..currency
-					elseif item.name == 'black_money' then
-						missing = '$'..ESX.Math.GroupDigits(ESX.Round(data.price - money)).. ' '..string.lower(item.label)
-					else
-						missing = ''..ESX.Math.GroupDigits(ESX.Round(data.price - money))..' '..currency
-					end
+					local missing = ''
+					if currency == 'bank' or item.name:find('money') then missing = '$' end
+					missing = missing..ESX.Math.GroupDigits(ESX.Round(data.price - money))..' '..currency
 					TriggerClientEvent('mythic_notify:client:SendAlert', xPlayer.source, { type = 'error', text = _U('cannot_afford', missing) })
 				end
 			end
@@ -540,24 +531,27 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 						Drops[invid].inventory[data.toSlot] = {name = data.newslotItem.name, label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stack = data.newslotItem.stack, close = Items[data.newslotItem.name].close}
 					end
 				end
-			else		
+			else
 				if data.type == 'swap' then
 					if ValidateItem(data.type, xPlayer, Inventories[invid].inventory[data.fromSlot], Inventories[invid].inventory[data.toSlot], data.fromItem, data.toItem) == true then
 						Inventories[invid].inventory[data.toSlot] = {name = data.toItem.name, label = data.toItem.label, weight = data.toItem.weight, slot = data.toSlot, count = data.toItem.count, description = data.toItem.description, metadata = data.toItem.metadata, stack = data.toItem.stack, close = Items[data.toItem.name].close}
 						Inventories[invid].inventory[data.fromSlot] = {name = data.fromItem.name, label = data.fromItem.label, weight = data.fromItem.weight, slot = data.fromSlot, count = data.fromItem.count, description = data.fromItem.description, metadata = data.fromItem.metadata, stack = data.fromItem.stack, close = Items[data.fromItem.name].close}
 						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end
+						TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot], data.fromSlot, Inventories[invid].inventory[data.fromSlot]})
 					end
 				elseif data.type == 'freeslot' then
 					if ValidateItem(data.type, xPlayer, Inventories[invid].inventory[data.emptyslot], Inventories[invid].inventory[data.toSlot], data.item, data.item) == true then
 						Inventories[invid].inventory[data.emptyslot] = nil
 						Inventories[invid].inventory[data.toSlot] = {name = data.item.name, label = data.item.label, weight = data.item.weight, slot = data.toSlot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stack = data.item.stack, close = Items[data.item.name].close}
 						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end
+						TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot], data.emptyslot, Inventories[invid].inventory[data.emptyslot]})
 					end
 				elseif data.type == 'split' then
 					if ValidateItem(data.type, xPlayer, Inventories[invid].inventory[data.fromSlot], Inventories[invid].inventory[data.toSlot], data.oldslotItem, data.newslotItem) == true then
 						Inventories[invid].inventory[data.fromSlot] = {name = data.oldslotItem.name, label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stack = data.oldslotItem.stack, close = Items[data.oldslotItem.name].close}
 						Inventories[invid].inventory[data.toSlot] = {name = data.newslotItem.name, label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stack = data.newslotItem.stack, close = Items[data.newslotItem.name].close}
 						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end
+						TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot], data.fromSlot, Inventories[invid].inventory[data.fromSlot]})
 					end
 				end
 			end
@@ -585,7 +579,8 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 							ItemNotify(xPlayer, data.fromItem, data.fromItem.count, data.toSlot, 'added')
 							Drops[dropid].inventory[data.toSlot] = {name = data.toItem.name, label = data.toItem.label, weight = data.toItem.weight, slot = data.toSlot, count = data.toItem.count, description = data.toItem.description, metadata = data.toItem.metadata, stack = data.toItem.stack, close = Items[data.toItem.name].close}
 							Inventories[invid2].inventory[data.fromSlot] = {name = data.fromItem.name, label = data.fromItem.label, weight = data.fromItem.weight, slot = data.fromSlot, count = data.fromItem.count, description = data.fromItem.description, metadata = data.fromItem.metadata, stack = data.fromItem.stack, close = Items[data.fromItem.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has swapped '..data.toItem.count..'x '..data.toItem.name..' for '..data.fromItem.count..'x '..data.fromItem.name..' in drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has swapped '..data.toItem.count..'x '..data.toItem.name..' for '..data.fromItem.count..'x '..data.fromItem.name..' in'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]})
 						end
 					elseif data.type == 'freeslot' then
 						if ValidateItem(data.type, xPlayer, Inventories[invid2].inventory[data.emptyslot], Drops[dropid].inventory[data.toSlot], data.item, data.item) == true then
@@ -593,14 +588,16 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 							ItemNotify(xPlayer, data.item, count, data.emptyslot, 'removed')
 							Inventories[invid2].inventory[data.emptyslot] = nil
 							Drops[dropid].inventory[data.toSlot] = {name = data.item.name, label = data.item.label, weight = data.item.weight, slot = data.toSlot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stack = data.item.stack, close = Items[data.item.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has stored '..count..'x '..data.item.name..' in drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has stored '..count..'x '..data.item.name..' in'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.emptyslot, nil})
 						end
 					elseif data.type == 'split' then
 						if ValidateItem(data.type, xPlayer, Inventories[invid2].inventory[data.fromSlot], Drops[dropid].inventory[data.toSlot], data.oldslotItem, data.newslotItem) == true then
 							ItemNotify(xPlayer, data.newslotItem, data.newslotItem.count, data.fromSlot, 'removed')
 							Inventories[invid2].inventory[data.fromSlot] = {name = data.oldslotItem.name, label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stack = data.oldslotItem.stack, close = Items[data.oldslotItem.name].close}
 							Drops[dropid].inventory[data.toSlot] = {name = data.newslotItem.name, label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stack = data.newslotItem.stack, close = Items[data.newslotItem.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has stored '..data.newslotItem.count..'x '..data.newslotItem.name..' in drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has stored '..data.newslotItem.count..'x '..data.newslotItem.name..' in'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]})
 						end
 					end
 				elseif data.toinv == 'Playerinv' then
@@ -611,7 +608,8 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 							ItemNotify(xPlayer, data.fromItem, data.fromItem.count, data.fromSlot, 'removed')
 							Inventories[invid].inventory[data.toSlot] = {name = data.toItem.name, label = data.toItem.label, weight = data.toItem.weight, slot = data.toSlot, count = data.toItem.count, description = data.toItem.description, metadata = data.toItem.metadata, stack = data.toItem.stack, close = Items[data.toItem.name].close}
 							Drops[dropid].inventory[data.fromSlot] = {name = data.fromItem.name, label = data.fromItem.label, weight = data.fromItem.weight, slot = data.fromSlot, count = data.fromItem.count, description = data.fromItem.description, metadata = data.fromItem.metadata, stack = data.fromItem.stack, close = Items[data.fromItem.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has swapped '..data.fromItem.count..'x '..data.fromItem.name..' for '..data.toItem.count..'x '..data.toItem.name.. 'in drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has swapped '..data.fromItem.count..'x '..data.fromItem.name..' for '..data.toItem.count..'x '..data.toItem.name.. 'in'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
 						end
 					elseif data.type == 'freeslot' then
 						if ValidateItem(data.type, xPlayer, Drops[dropid].inventory[data.emptyslot], Inventories[invid].inventory[data.toSlot], data.item, data.item) == true then
@@ -619,14 +617,16 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 							ItemNotify(xPlayer, data.item, count, data.toSlot, 'added')
 							Drops[dropid].inventory[data.emptyslot] = nil
 							Inventories[invid].inventory[data.toSlot] = {name = data.item.name, label = data.item.label, weight = data.item.weight, slot = data.toSlot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stack = data.item.stack, close = Items[data.item.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has taken '..count..'x '..data.item.name..' from drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has taken '..count..'x '..data.item.name..' from'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
 						end
 					elseif data.type == 'split' then
 						if ValidateItem(data.type, xPlayer, Drops[dropid].inventory[data.fromSlot], Inventories[invid].inventory[data.toSlot], data.oldslotItem, data.newslotItem) == true then
 							ItemNotify(xPlayer, data.newslotItem, data.toSlot, false, 'added')
 							Drops[dropid].inventory[data.fromSlot] = {name = data.oldslotItem.name, label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stack = data.oldslotItem.stack, close = Items[data.oldslotItem.name].close}
 							Inventories[invid].inventory[data.toSlot] = {name = data.newslotItem.name, label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stack = data.newslotItem.stack, close = Items[data.newslotItem.name].close}
-							if Config.Logs then CreateLog(xPlayer.source, false, 'has taken '..data.newslotItem.count..'x '..data.newslotItem.name..' from drop-'..dropid, 'drop') end
+							if Config.Logs then CreateLog(xPlayer.source, false, 'has taken '..data.newslotItem.count..'x '..data.newslotItem.name..' from'..dropid, 'drop') end
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
 						end
 					end
 				end
@@ -673,6 +673,13 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 						Inventories[invid].inventory[data.toSlot] = {name = data.toItem.name, label = data.toItem.label, weight = data.toItem.weight, slot = data.toSlot, count = data.toItem.count, description = data.toItem.description, metadata = data.toItem.metadata, stack = data.toItem.stack, close = Items[data.toItem.name].close}
 						Inventories[invid2].inventory[data.fromSlot] = {name = data.fromItem.name, label = data.fromItem.label, weight = data.fromItem.weight, slot = data.fromSlot, count = data.fromItem.count, description = data.fromItem.description, metadata = data.fromItem.metadata, stack = data.fromItem.stack, close = Items[data.fromItem.name].close}
 						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end if invid2 ~= xPlayer.source and invid2 ~= xTarget.source then Inventories[invid2].set('changed', true) end
+						if invid == xPlayer.source then -- to self inventory
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]}) end
+						else
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]}) end
+						end
 					end
 				elseif data.type == 'freeslot' then
 					if ValidateItem(data.type, xPlayer, Inventories[invid2].inventory[data.emptyslot], Inventories[invid].inventory[data.toSlot], data.item, data.item) == true then
@@ -697,6 +704,13 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 						Inventories[invid2].inventory[data.emptyslot] = nil
 						Inventories[invid].inventory[data.toSlot] = {name = data.item.name, label = data.item.label, weight = data.item.weight, slot = data.toSlot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stack = data.item.stack, close = Items[data.item.name].close}
 						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end if invid2 ~= xPlayer.source and invid2 ~= xTarget.source then Inventories[invid2].set('changed', true) end
+						if invid == xPlayer.source then -- to self inventory
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.emptyslot, Inventories[invid2].inventory[data.emptyslot]}) end
+						else
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.emptyslot, Inventories[invid2].inventory[data.emptyslot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]}) end
+						end
 					end
 				elseif data.type == 'split' then
 					if ValidateItem(data.type, xPlayer, Inventories[invid2].inventory[data.fromSlot], Inventories[invid].inventory[data.toSlot], data.oldslotItem, data.newslotItem) == true then
@@ -719,14 +733,20 @@ AddEventHandler('linden_inventory:saveInventoryData', function(data)
 						end
 						Inventories[invid2].inventory[data.fromSlot] = {name = data.oldslotItem.name, label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stack = data.oldslotItem.stack, close = Items[data.oldslotItem.name].close}
 						Inventories[invid].inventory[data.toSlot] = {name = data.newslotItem.name, label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stack = data.newslotItem.stack, close = Items[data.newslotItem.name].close}
+						if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end if invid2 ~= xPlayer.source and invid2 ~= xTarget.source then Inventories[invid2].set('changed', true) end
+						if invid == xPlayer.source then -- to self inventory
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]}) end
+						else
+							TriggerClientEvent('linden_inventory:update', xPlayer.source, {data.fromSlot, Inventories[invid2].inventory[data.fromSlot]})
+							if targetId then TriggerClientEvent('linden_inventory:update', xTarget.source, {data.toSlot, Inventories[invid].inventory[data.toSlot]}) end
+						end
 					end
-					if invid ~= xPlayer.source and invid ~= xTarget.source then Inventories[invid].set('changed', true) end if invid2 ~= xPlayer.source and invid2 ~= xTarget.source then Inventories[invid2].set('changed', true) end
 				end
 			end
 		end
 	end
 end)
-
 
 RegisterNetEvent('linden_inventory:saveInventory')
 AddEventHandler('linden_inventory:saveInventory', function(data)
@@ -800,9 +820,7 @@ AddEventHandler('linden_inventory:reloadWeapon', function(weapon)
 	if Inventories[xPlayer.source].inventory[weapon.slot] then
 		local ammo = Items[Items[weapon.name].ammoname]
 		ammo.count = getInventoryItem(xPlayer, ammo.name).count
-		if ammo.count then Inventories[xPlayer.source].inventory[weapon.slot].metadata.ammo = 0
-			if ammo.count > 0 then TriggerClientEvent('linden_inventory:addAmmo', xPlayer.source, ammo) end
-		end
+		if ammo.count > 0 then TriggerClientEvent('linden_inventory:addAmmo', xPlayer.source, ammo) end
 	else TriggerClientEvent('linden_inventory:clearWeapons', xPlayer.source) end
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -257,7 +257,7 @@ AddEventHandler('linden_inventory:openInventory', function(invType, data, player
 				local shop = Config.Shops[data]
 				if (not shop.job or shop.job == xPlayer.job.name) and (not shop.grade or shop.grade <= xPlayer.job.grade) then
 					local srcCoords = GetEntityCoords(GetPlayerPed(xPlayer.source))
-					if #(shop.coords - srcCoords) <= 2 then
+					if #(shop.coords - srcCoords) <= 10 then
 						if shop.currency and type(shop.currency) == 'string' and shop.currency ~= 'money' and shop.currency ~= 'black_money' then
 							local item = Items[shop.currency]
 							shop.currency = {name=item.name, label=item.label}
@@ -363,7 +363,7 @@ AddEventHandler('linden_inventory:giveStash', function(data)
 			
 			if data.coords then
 				local srcCoords = GetEntityCoords(GetPlayerPed(xPlayer.source))
-				if #(data.coords - srcCoords) > 4 then return false end
+				if #(data.coords - srcCoords) > 10 then return false end
 			end
 
 			if not Inventories[id] then

--- a/shared/shops.lua
+++ b/shared/shops.lua
@@ -75,7 +75,7 @@ Config.Medicine = {
 		scale = 0.6
 	}, inventory = {
 		{ name = 'medikit', price = 26 },
-		{ name = 'WEAPON_STUNGUN', price = 500, metadata = { registered = true, serial = 'EMS' } },
+		{ name = 'bandage', price = 5 },
 	}
 }
 
@@ -152,8 +152,8 @@ Config.Shops = {
 	{ coords = vector3(-2544.092, 2316.184, 33.2), name = 'RON'},
 
 	
-	{ type = Config.PoliceArmoury, job = 'police', grade = 2,  coords = vector3(487.235, -997.108, 30.69), RenderDist = 2, bt_length = 0.5, bt_width = 3.0, bt_heading = 60.0, bt_distance = 6},
-	{ type = Config.Medicine, job = 'ambulance', coords = vector3(306.3687, -601.5139, 43.28406) --[[ bt_length = 0.5, bt_width = 3.0, bt_minZ = 29.8, bt_maxZ = 32.0, bt_heading = 60.0, bt_distance = 6]] },
+	{ type = Config.PoliceArmoury, job = 'police', grade = 1,  coords = vector3(487.235, -997.108, 30.69), distance = 2 --[[, bt_length = 0.5, bt_width = 3.0, bt_heading = 60.0, bt_distance = 6]]},
+	{ type = Config.Medicine, job = 'ambulance', coords = vector3(306.3687, -601.5139, 43.28406) --[[, bt_length = 0.5, bt_width = 3.0, bt_minZ = 29.8, bt_maxZ = 32.0, bt_heading = 60.0, bt_distance = 6]] },
 
 	{ type = Config.BlackMarketArms, coords = vector3(309.09, -913.75, 56.46), currency = 'black_money' },
 }

--- a/shared/stashes.lua
+++ b/shared/stashes.lua
@@ -2,7 +2,7 @@ Config.PoliceEvidence = vector3(474.2242, -990.7516, 26.2638) -- /evidence # whi
 
 Config.Stashes = {
 	--{ coords = vector3(474.2242, -990.7516, 26.2638), slots = 70, name = 'Police Evidence', job = 'police' }, --using command instead
-	{ coords = vector3(462.7252, -999.5868, 30.67834), slots = 70, name = 'Personal Locker', owner = true, job = 'police', grade = 0, RenderDist = 2 },
+	{ coords = vector3(462.7252, -999.5868, 30.67834), slots = 70, name = 'Personal Locker', owner = true, job = 'police', grade = 0, distance = 2 },
 
 	{ coords = vector3(301.3054, -600.2374, 43.2821), slots = 70, name = 'Personal Locker', owner = true, job = 'ambulance'  },
 }


### PR DESCRIPTION
- Fixes
	- Resolved error when buying with dirty money
	- Resolved item use getting locked when trying to reload a gun without ammo
	- Check if ped is armed with a melee weapon, rather than in melee combat, to reduce durability

- Changes
	- Update ESX.PlayerData.inventory as items are moved
	- Register keybinds and hotkeys after the inventory has fully loaded
	- Update currentWeapon slot if it is moved to ensure correct data sync