### PR TITLE
fix(server/inventory): Fix weapon weight when ammo inside

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -84,7 +84,7 @@ M.SlotWeight = function(item, slot)
 		local ammo = {
 			type = item.ammoname,
 			count = slot.metadata.ammo,
-			weight = Items(item.ammoname).weight,
+			weight = Items(item.ammoname).weight
 		}
 		if ammo.count then weight = weight + ammo.weight * ammo.count end
 	end


### PR DESCRIPTION
Before changes:
![image](https://user-images.githubusercontent.com/48567607/137881561-42d9c92a-b801-4855-9400-962e74be16bf.png)

After changes:
![image](https://user-images.githubusercontent.com/48567607/137881475-2da6c349-e871-4b19-9b2f-85331db00765.png)
