### PR TITLE
fix(server/inventory): CanCarryItem returning false where an item should be able stack.

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1394,7 +1394,15 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 		inv = Inventory(inv) --[[@as OxInventory]]
 
 		if inv then
-			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item, type(metadata) == 'table' and metadata or { type = metadata or nil })
+			local md
+			if type(metadata) == 'table' then
+				md = metadata
+			elseif type(metadata) == 'string' then
+				md = { type = metadata }
+			else
+				md = {}
+			end
+			local itemSlots, _, emptySlots = Inventory.GetItemSlots(inv, item, md)
 
 			if not itemSlots then return end
 


### PR DESCRIPTION
Fixes #1906

----

Essentially when an inventory is full of items, when you try and check if you can add a stackable item that is in the inventory using `CanCarryItem`, it returns false. It seemed to stem from the strict metadata check.

When the metadata value is nil in CanCarryItem, the metadata table created is `{ type = nil }`. Lua treats that new table as a hashmap even though it's really just an empty table (at least `table.type` looks at the table like that), and it seems to break the strict metadata check.