### PR TITLE
Added possibility to give items through car windows

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1689,10 +1689,10 @@ local function isGiveTargetValid(ped, coords)
 
     local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
 
-    if(GetVehiclePedIsIn(ped, false) and not cache.vehicle) then
-		local currCoords=GetWorldPositionOfEntityBone(ped,0);
-		if( #( pedCoords.xy - currCoords.xy ) <= 2.0) then
-			return true;
+    if GetVehiclePedIsIn(ped, false) and not cache.vehicle then
+		local currCoords=GetWorldPositionOfEntityBone(ped,0)
+		if #(pedCoords.xy - currCoords.xy) <= 2.0 then
+			return true
 		end
 	end
 
@@ -1705,10 +1705,10 @@ RegisterNUICallback('giveItem', function(data, cb)
     if usingItem then return end
 
 	if client.giveplayerlist then
-		local coords=GetEntityCoords(playerPed);
+		local coords=GetEntityCoords(playerPed)
 		
-		if(cache.vehicle) then
-			coords=GetWorldPositionOfEntityBone(playerPed,0);
+		if cache.vehicle then
+			coords=GetWorldPositionOfEntityBone(playerPed,0)
 		end
 	
 		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)

--- a/client.lua
+++ b/client.lua
@@ -1689,6 +1689,13 @@ local function isGiveTargetValid(ped, coords)
 
     local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
 
+    if(GetVehiclePedIsIn(ped, false) and not cache.vehicle) then
+		local currCoords=GetWorldPositionOfEntityBone(ped,0);
+		if( #( pedCoords.xy - currCoords.xy ) <= 2.0) then
+			return true;
+		end
+	end
+
     return entity == ped and IsEntityVisible(ped)
 end
 
@@ -1698,7 +1705,13 @@ RegisterNUICallback('giveItem', function(data, cb)
     if usingItem then return end
 
 	if client.giveplayerlist then
-		local nearbyPlayers = lib.getNearbyPlayers(GetEntityCoords(playerPed), 3.0)
+		local coords=GetEntityCoords(playerPed);
+		
+		if(cache.vehicle) then
+			coords=GetWorldPositionOfEntityBone(playerPed,0);
+		end
+	
+		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
         local nearbyCount = #nearbyPlayers
 
 		if nearbyCount == 0 then return end

--- a/client.lua
+++ b/client.lua
@@ -1705,11 +1705,7 @@ RegisterNUICallback('giveItem', function(data, cb)
     if usingItem then return end
 
 	if client.giveplayerlist then
-		local coords=GetEntityCoords(playerPed)
-		
-		if cache.vehicle then
-			coords=GetWorldPositionOfEntityBone(playerPed, 0)
-		end
+		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
 	
 		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
         local nearbyCount = #nearbyPlayers

--- a/client.lua
+++ b/client.lua
@@ -1690,7 +1690,7 @@ local function isGiveTargetValid(ped, coords)
     local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
 
     if GetVehiclePedIsIn(ped, false) and not cache.vehicle then
-		local currCoords=GetWorldPositionOfEntityBone(ped,0)
+		local currCoords=GetWorldPositionOfEntityBone(ped, 0)
 		if #(pedCoords.xy - currCoords.xy) <= 2.0 then
 			return true
 		end
@@ -1708,7 +1708,7 @@ RegisterNUICallback('giveItem', function(data, cb)
 		local coords=GetEntityCoords(playerPed)
 		
 		if cache.vehicle then
-			coords=GetWorldPositionOfEntityBone(playerPed,0)
+			coords=GetWorldPositionOfEntityBone(playerPed, 0)
 		end
 	
 		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)

--- a/client.lua
+++ b/client.lua
@@ -184,13 +184,13 @@ function client.openInventory(inv, data)
     end
 
     if inv == 'shop' and invOpen == false then
-        if  then
+        if cache.vehicle then
             return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
         end
 
         left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
     elseif inv == 'crafting' then
-        if  then
+        if cache.vehicle then
             return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
         end
 
@@ -254,7 +254,7 @@ function client.openInventory(inv, data)
     end
 
 
-    if not  then
+    if not cache.vehicle then
         if inv == 'player' then
             Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
         elseif inv ~= 'trunk' then
@@ -1705,7 +1705,11 @@ RegisterNUICallback('giveItem', function(data, cb)
     if usingItem then return end
 
 	if client.giveplayerlist then
-		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
+		local coords=GetEntityCoords(playerPed)
+		
+		if cache.vehicle then
+			coords=GetWorldPositionOfEntityBone(playerPed, 0)
+		end
 	
 		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
         local nearbyCount = #nearbyPlayers

--- a/client.lua
+++ b/client.lua
@@ -1687,14 +1687,7 @@ local function isGiveTargetValid(ped, coords)
         return true
     end
 
-    local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
-
-    if GetVehiclePedIsIn(ped, false) and not cache.vehicle then
-		local currCoords=GetWorldPositionOfEntityBone(ped, 0)
-		if #(pedCoords.xy - currCoords.xy) <= 2.0 then
-			return true
-		end
-	end
+    local entity = Utils.Raycast(1|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
 
     return entity == ped and IsEntityVisible(ped)
 end

--- a/client.lua
+++ b/client.lua
@@ -184,13 +184,13 @@ function client.openInventory(inv, data)
     end
 
     if inv == 'shop' and invOpen == false then
-        if cache.vehicle then
+        if  then
             return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
         end
 
         left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
     elseif inv == 'crafting' then
-        if cache.vehicle then
+        if  then
             return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
         end
 
@@ -254,7 +254,7 @@ function client.openInventory(inv, data)
     end
 
 
-    if not cache.vehicle then
+    if not  then
         if inv == 'player' then
             Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
         elseif inv ~= 'trunk' then
@@ -1705,11 +1705,7 @@ RegisterNUICallback('giveItem', function(data, cb)
     if usingItem then return end
 
 	if client.giveplayerlist then
-		local coords=GetEntityCoords(playerPed)
-		
-		if cache.vehicle then
-			coords=GetWorldPositionOfEntityBone(playerPed, 0)
-		end
+		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
 	
 		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
         local nearbyCount = #nearbyPlayers


### PR DESCRIPTION
In the current iteration of inventory, giving items through windows of vehicles is not possible: i.e. if player A is near the driver window and player B is sitting in driver seat.

This PR adds that (along with https://github.com/overextended/ox_lib/pull/757 ) as a feature.