### PR TITLE
feat(ui): Add thousands separator formatting to item amount input

### DIFF
--- a/web/src/components/inventory/InventoryControl.tsx
+++ b/web/src/components/inventory/InventoryControl.tsx
@@ -9,14 +9,18 @@ import { fetchNui } from '../../utils/fetchNui';
 import { Locale } from '../../store/locale';
 import UsefulControls from './UsefulControls';
 
+const formatAmount = (n: number) => (n ? n.toLocaleString('en-US') : '');
+const digitsOnly = (s: string) => s.replace(/\D/g, '');
+const countDigitsBefore = (s: string, index: number) => digitsOnly(s.substring(0, index)).length;
+
 const InventoryControl: React.FC = () => {
   const itemAmount = useAppSelector(selectItemAmount);
   const dispatch = useAppDispatch();
 
   const [infoVisible, setInfoVisible] = useState(false);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(formatAmount(itemAmount));
   const inputRef = useRef<HTMLInputElement>(null);
-  const cursorRef = useRef<{ digitsBefore: number; formattedValue: string } | null>(null);
+  const cursorRef = useRef<number | null>(null);
 
   const [, use] = useDrop<DragSource, void, any>(() => ({
     accept: 'SLOT',
@@ -32,88 +36,45 @@ const InventoryControl: React.FC = () => {
     },
   }));
 
+  const commitValue = (raw: string, cursorIndex: number) => {
+    const digitsBefore = countDigitsBefore(raw, cursorIndex);
+    const num = parseInt(digitsOnly(raw), 10) || 0;
+
+    setValue(formatAmount(num));
+    dispatch(setItemAmount(num));
+    cursorRef.current = digitsBefore;
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    commitValue(event.target.value, event.target.selectionStart ?? 0);
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const el = event.currentTarget;
     const pos = el.selectionStart ?? 0;
-    const selEnd = el.selectionEnd ?? 0;
-    const rawValue = el.value;
 
-    // If there's a range selection, let default behavior handle it
-    if (pos !== selEnd) return;
+    if (pos !== el.selectionEnd) return;
 
-    if (event.key === 'Backspace' && pos > 0 && /[^0-9]/.test(rawValue[pos - 1])) {
-      // Cursor is right after a comma: delete the comma AND the digit before it
+    if (event.key === 'Backspace' && el.value[pos - 1] === ',') {
       event.preventDefault();
-      if (pos < 2) return;
-      const newRaw = rawValue.slice(0, pos - 2) + rawValue.slice(pos);
-      const digits = newRaw.replace(/[^0-9]/g, '');
-      if (digits === '') {
-        cursorRef.current = null;
-        setValue('');
-        dispatch(setItemAmount(0));
-        return;
-      }
-      const formatted = Number(digits).toLocaleString('en-us');
-      const digitsBeforeCursor = (rawValue.slice(0, pos - 2).replace(/[^0-9]/g, '')).length;
-      setValue(formatted);
-      cursorRef.current = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
-      dispatch(setItemAmount(Math.floor(Math.max(0, Number(digits)))));
-    } else if (event.key === 'Delete' && pos < rawValue.length && /[^0-9]/.test(rawValue[pos])) {
-      // Cursor is right before a comma: delete the comma AND the digit after it
+      commitValue(el.value.slice(0, pos - 2) + el.value.slice(pos), pos - 2);
+    } else if (event.key === 'Delete' && el.value[pos] === ',') {
       event.preventDefault();
-      if (pos + 1 >= rawValue.length) return;
-      const newRaw = rawValue.slice(0, pos) + rawValue.slice(pos + 2);
-      const digits = newRaw.replace(/[^0-9]/g, '');
-      if (digits === '') {
-        cursorRef.current = null;
-        setValue('');
-        dispatch(setItemAmount(0));
-        return;
-      }
-      const formatted = Number(digits).toLocaleString('en-us');
-      const digitsBeforeCursor = (rawValue.slice(0, pos).replace(/[^0-9]/g, '')).length;
-      setValue(formatted);
-      cursorRef.current = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
-      dispatch(setItemAmount(Math.floor(Math.max(0, Number(digits)))));
+      commitValue(el.value.slice(0, pos) + el.value.slice(pos + 2), pos);
     }
   };
 
-  const inputHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const el = event.target;
-    const rawValue = el.value;
-    const selectionStart = el.selectionStart ?? 0;
-    const beforeCursor = rawValue.substring(0, selectionStart);
-    const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
-    const digits = rawValue.replace(/[^0-9]/g, "");
-    if (digits === "") {
-      cursorRef.current = null;
-      setValue("");
-      dispatch(setItemAmount(0));
-      return;
-    }
-    const formatted = Number(digits).toLocaleString('en-us');
-    const digitsBeforeCursor = selectionStart - commaCountBefore;
-    setValue(formatted);
-    cursorRef.current = {
-      digitsBefore: digitsBeforeCursor,
-      formattedValue: formatted
-    };
-    const numValue = Math.floor(Math.max(0, Number(digits)));
-    dispatch(setItemAmount(isNaN(numValue) ? 0 : numValue));
-  };
   useEffect(() => {
-    if (inputRef.current && cursorRef.current !== null) {
-      const { digitsBefore, formattedValue } = cursorRef.current;
-      let newPos = 0;
-      let count = 0;
+    if (!inputRef.current || cursorRef.current === null) return;
+    let newPos = 0;
+    let count = 0;
 
-      for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
-        if (/[0-9]/.test(formattedValue[i])) count++;
-        newPos++;
-      }
-
-      inputRef.current.setSelectionRange(newPos, newPos);
+    for (let i = 0; i < value.length && count < cursorRef.current; i++) {
+      if (/\d/.test(value[i])) count++;
+      newPos++;
     }
+
+    inputRef.current.setSelectionRange(newPos, newPos);
+    cursorRef.current = null;
   }, [value]);
 
   return (
@@ -125,9 +86,8 @@ const InventoryControl: React.FC = () => {
             className="inventory-control-input"
             type="text"
             ref={inputRef}
-            defaultValue={itemAmount}
             value={value}
-            onChange={inputHandler}
+            onChange={handleChange}
             onKeyDown={handleKeyDown}
             min={0}
           />

--- a/web/src/components/inventory/InventoryControl.tsx
+++ b/web/src/components/inventory/InventoryControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { selectItemAmount, setItemAmount } from '../../store/inventory';
@@ -14,6 +14,9 @@ const InventoryControl: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const [infoVisible, setInfoVisible] = useState(false);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cursorRef = useRef<{ digitsBefore: number; formattedValue: string } | null>(null);
 
   const [, use] = useDrop<DragSource, void, any>(() => ({
     accept: 'SLOT',
@@ -30,10 +33,41 @@ const InventoryControl: React.FC = () => {
   }));
 
   const inputHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.target.valueAsNumber =
-      isNaN(event.target.valueAsNumber) || event.target.valueAsNumber < 0 ? 0 : Math.floor(event.target.valueAsNumber);
-    dispatch(setItemAmount(event.target.valueAsNumber));
+    const el = event.target;
+    const rawValue = el.value;
+    const selectionStart = el.selectionStart ?? 0;
+    const beforeCursor = rawValue.substring(0, selectionStart);
+    const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
+    const digits = rawValue.replace(/[^0-9]/g, "");
+    if (digits === "") {
+      setValue("");
+      dispatch(setItemAmount(0));
+      return;
+    }
+    const formatted = Number(digits).toLocaleString('en-us');
+    const digitsBeforeCursor = selectionStart - commaCountBefore;
+    setValue(formatted);
+    cursorRef.current = {
+      digitsBefore: digitsBeforeCursor,
+      formattedValue: formatted
+    };
+    const numValue = Math.floor(Math.max(0, Number(digits)));
+    dispatch(setItemAmount(isNaN(numValue) ? 0 : numValue));
   };
+  useEffect(() => {
+    if (inputRef.current && cursorRef.current !== null) {
+      const { digitsBefore, formattedValue } = cursorRef.current;
+      let newPos = 0;
+      let count = 0;
+
+      for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
+        if (/[0-9]/.test(formattedValue[i])) count++;
+        newPos++;
+      }
+
+      inputRef.current.setSelectionRange(newPos, newPos);
+    }
+  }, [value]);
 
   return (
     <>
@@ -42,8 +76,10 @@ const InventoryControl: React.FC = () => {
         <div className="inventory-control-wrapper">
           <input
             className="inventory-control-input"
-            type="number"
+            type="text"
+            ref={inputRef}
             defaultValue={itemAmount}
+            value={value}
             onChange={inputHandler}
             min={0}
           />

--- a/web/src/components/inventory/InventoryControl.tsx
+++ b/web/src/components/inventory/InventoryControl.tsx
@@ -9,7 +9,7 @@ import { fetchNui } from '../../utils/fetchNui';
 import { Locale } from '../../store/locale';
 import UsefulControls from './UsefulControls';
 
-const formatAmount = (n: number) => (n ? n.toLocaleString('en-US') : '');
+const formatAmount = (n: number) => (n > 0 ? n.toLocaleString('en-US') : '0');
 const digitsOnly = (s: string) => s.replace(/\D/g, '');
 const countDigitsBefore = (s: string, index: number) => digitsOnly(s.substring(0, index)).length;
 

--- a/web/src/components/inventory/InventoryControl.tsx
+++ b/web/src/components/inventory/InventoryControl.tsx
@@ -32,6 +32,52 @@ const InventoryControl: React.FC = () => {
     },
   }));
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const el = event.currentTarget;
+    const pos = el.selectionStart ?? 0;
+    const selEnd = el.selectionEnd ?? 0;
+    const rawValue = el.value;
+
+    // If there's a range selection, let default behavior handle it
+    if (pos !== selEnd) return;
+
+    if (event.key === 'Backspace' && pos > 0 && /[^0-9]/.test(rawValue[pos - 1])) {
+      // Cursor is right after a comma: delete the comma AND the digit before it
+      event.preventDefault();
+      if (pos < 2) return;
+      const newRaw = rawValue.slice(0, pos - 2) + rawValue.slice(pos);
+      const digits = newRaw.replace(/[^0-9]/g, '');
+      if (digits === '') {
+        cursorRef.current = null;
+        setValue('');
+        dispatch(setItemAmount(0));
+        return;
+      }
+      const formatted = Number(digits).toLocaleString('en-us');
+      const digitsBeforeCursor = (rawValue.slice(0, pos - 2).replace(/[^0-9]/g, '')).length;
+      setValue(formatted);
+      cursorRef.current = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
+      dispatch(setItemAmount(Math.floor(Math.max(0, Number(digits)))));
+    } else if (event.key === 'Delete' && pos < rawValue.length && /[^0-9]/.test(rawValue[pos])) {
+      // Cursor is right before a comma: delete the comma AND the digit after it
+      event.preventDefault();
+      if (pos + 1 >= rawValue.length) return;
+      const newRaw = rawValue.slice(0, pos) + rawValue.slice(pos + 2);
+      const digits = newRaw.replace(/[^0-9]/g, '');
+      if (digits === '') {
+        cursorRef.current = null;
+        setValue('');
+        dispatch(setItemAmount(0));
+        return;
+      }
+      const formatted = Number(digits).toLocaleString('en-us');
+      const digitsBeforeCursor = (rawValue.slice(0, pos).replace(/[^0-9]/g, '')).length;
+      setValue(formatted);
+      cursorRef.current = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
+      dispatch(setItemAmount(Math.floor(Math.max(0, Number(digits)))));
+    }
+  };
+
   const inputHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const el = event.target;
     const rawValue = el.value;
@@ -40,6 +86,7 @@ const InventoryControl: React.FC = () => {
     const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
     const digits = rawValue.replace(/[^0-9]/g, "");
     if (digits === "") {
+      cursorRef.current = null;
       setValue("");
       dispatch(setItemAmount(0));
       return;
@@ -81,6 +128,7 @@ const InventoryControl: React.FC = () => {
             defaultValue={itemAmount}
             value={value}
             onChange={inputHandler}
+            onKeyDown={handleKeyDown}
             min={0}
           />
           <button className="inventory-control-button" ref={use}>


### PR DESCRIPTION
## Summary

Replace the `type="number"` input with a `type="text"` input for the item
amount field in `InventoryControl`, and apply comma-separated thousands
formatting (e.g. `1,000`, `10,000`) using `toLocaleString('en-us')`.

## Changes

- Changed input type from `number` to `text`
- Format the entered value with thousands separators on each keystroke
- Preserve cursor position after formatting using `useRef` and `useEffect`
- Strip non-numeric characters before dispatching the value to the Redux store

## Motivation

The default `number` input does not display thousand separators, making it
difficult to read large quantities at a glance. This change improves
readability without affecting the underlying numeric value stored in state.

## Testing

- Type a large number (e.g. `1000000`) and verify it displays as `1,000,000`
- Verify the cursor does not jump to the end while editing mid-value
- Verify that the dispatched amount is correct (no commas included)
- Verify that empty input resets the amount to `0`

## Demo
<img width="240" height="240" alt="563879358-03f1a7ad-6307-42d4-9742-64dd8cd9633d" src="https://github.com/user-attachments/assets/94c0a636-9d99-4b51-8386-c54a342a5467" />

