### PR TITLE
fix(server/crafting): validate ingredient slots have not been replaced during craft progress

### DIFF
--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -164,7 +164,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			table.wipe(tbl)
 
 			for name, needs in pairs(recipe.ingredients) do
-				if needs == 0 then goto continue end
+				if needs == 0 then break end
 
 				local slots = items[name] or items
 
@@ -194,8 +194,6 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					-- Player does not have enough items (ui should prevent crafting if lacking items, so this shouldn't trigger)
 					if needs > 0 and i == #slots then return end
 				end
-
-				::continue::
 			end
 
 			if not TriggerEventHooks('craftItem', {

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -164,7 +164,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			table.wipe(tbl)
 
 			for name, needs in pairs(recipe.ingredients) do
-				if needs == 0 then break end
+				if needs == 0 then goto continue end
 
 				local slots = items[name] or items
 
@@ -194,6 +194,8 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					-- Player does not have enough items (ui should prevent crafting if lacking items, so this shouldn't trigger)
 					if needs > 0 and i == #slots then return end
 				end
+
+				::continue::
 			end
 
 			if not TriggerEventHooks('craftItem', {

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -167,19 +167,19 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 								local percentage = ((durability - os.time()) * 100) / degrade
 
 								if percentage >= needs * 100 then
-									tbl[slot.slot] = needs
+									tbl[slot.slot] = { name = name, count = needs }
 									break
 								end
 							else
-								tbl[slot.slot] = needs
+								tbl[slot.slot] = { name = name, count = needs }
 								break
 							end
 						end
 					elseif needs <= slot.count then
-						tbl[slot.slot] = needs
+						tbl[slot.slot] = { name = name, count = needs }
 						break
 					else
-						tbl[slot.slot] = slot.count
+						tbl[slot.slot] = { name = name, count = slot.count }
 						needs -= slot.count
 					end
 
@@ -205,19 +205,25 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					if Inventory.GetItemCount(left, name) < needs then return end
 				end
 
-				for slot, count in pairs(tbl) do
+				for slot, info in pairs(tbl) do
 					local invSlot = left.items[slot]
+					local count = info.count
 
-					if not invSlot then return end
+					if not invSlot or invSlot.name ~= info.name then return end
 
 					if count < 1 then
-						local item = Items(invSlot.name)
-						local durability = invSlot.metadata.durability or 100
+						local item = Items(info.name)
+						local durability = invSlot.metadata.durability
+
+						if not durability then return end
 
 						if durability > 100 then
 							local degrade = (invSlot.metadata.degrade or item.degrade) * 60
+							local percentage = ((durability - os.time()) * 100) / degrade
+							if percentage < count * 100 then return end
 							durability -= degrade * count
 						else
+							if durability < count * 100 then return end
 							durability -= count * 100
 						end
 
@@ -245,8 +251,9 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
                             Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
 						end
 					else
-						local removed = invSlot and Inventory.RemoveItem(left, invSlot.name, count, nil, slot)
-						-- Failed to remove item (inventory state unexpectedly changed?)
+						if invSlot.count < count then return end
+
+						local removed = Inventory.RemoveItem(left, info.name, count, nil, slot)
 						if not removed then return end
 					end
 				end

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -3,6 +3,7 @@ if not lib then return end
 local CraftingBenches = {}
 local Items = require 'modules.items.server'
 local Inventory = require 'modules.inventory.server'
+local Utils = require 'modules.utils.server'
 
 ---@param id number
 ---@param data table
@@ -96,6 +97,25 @@ end)
 
 local TriggerEventHooks = require 'modules.hooks.server'
 
+---@param slot { metadata: table, count: integer }
+---@param item table
+---@param needs number
+---@param ostime integer
+---@return boolean eligible, number? durability, number? degrade
+local function checkFractionEligibility(slot, item, needs, ostime)
+	local durability = slot.metadata.durability
+
+	if not durability then return false end
+
+	if durability > 100 then
+		local degrade = (slot.metadata.degrade or item.degrade) * 60
+		local percentage = ((durability - ostime) * 100) / degrade
+		return percentage >= needs * 100, durability, degrade
+	end
+
+	return durability >= needs * 100, durability
+end
+
 lib.callback.register('ox_inventory:craftItem', function(source, id, index, recipeId, toSlot)
 	local left, bench = Inventory(source), CraftingBenches[id]
 
@@ -158,22 +178,9 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							break
 						end
 					elseif needs < 1 then
-						local item = Items(name)
-						local durability = slot.metadata.durability
-
-						if durability and durability >= needs * 100 then
-							if durability > 100 then
-								local degrade = (slot.metadata.degrade or item.degrade) * 60
-								local percentage = ((durability - os.time()) * 100) / degrade
-
-								if percentage >= needs * 100 then
-									tbl[slot.slot] = { name = name, count = needs }
-									break
-								end
-							else
-								tbl[slot.slot] = { name = name, count = needs }
-								break
-							end
+						if checkFractionEligibility(slot, Items(name), needs, os.time()) then
+							tbl[slot.slot] = { name = name, count = needs }
+							break
 						end
 					elseif needs <= slot.count then
 						tbl[slot.slot] = { name = name, count = needs }
@@ -201,29 +208,28 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			local success = lib.callback.await('ox_inventory:startCrafting', source, id, recipeId)
 
 			if success then
-				for name, needs in pairs(recipe.ingredients) do
-					if Inventory.GetItemCount(left, name) < needs then return end
-				end
+				local ostime = os.time()
 
-				for slot, info in pairs(tbl) do
+				for slot, entry in pairs(tbl) do
 					local invSlot = left.items[slot]
-					local count = info.count
+					local count = entry.count
 
-					if not invSlot or invSlot.name ~= info.name then return end
+					if not invSlot then return end
+
+					if invSlot.name ~= entry.name then
+						Utils.LogExploit(source, 'craftItem', ('Ingredient slot %s changed from "%s" to "%s" during craft.'):format(slot, entry.name, invSlot.name))
+						return
+					end
 
 					if count < 1 then
-						local item = Items(info.name)
-						local durability = invSlot.metadata.durability
+						local item = Items(entry.name)
+						local eligible, durability, degrade = checkFractionEligibility(invSlot, item, count, ostime)
 
-						if not durability then return end
+						if not eligible then return end
 
-						if durability > 100 then
-							local degrade = (invSlot.metadata.degrade or item.degrade) * 60
-							local percentage = ((durability - os.time()) * 100) / degrade
-							if percentage < count * 100 then return end
+						if degrade then
 							durability -= degrade * count
 						else
-							if durability < count * 100 then return end
 							durability -= count * 100
 						end
 
@@ -253,7 +259,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					else
 						if invSlot.count < count then return end
 
-						local removed = Inventory.RemoveItem(left, info.name, count, nil, slot)
+						local removed = Inventory.RemoveItem(left, entry.name, count, nil, slot)
 						if not removed then return end
 					end
 				end


### PR DESCRIPTION
## Summary

`craftItem` had a distinct bug that results in a free-craft exploit:

1. **Slot identity was dropped between build and consume.** The ingredient slot list (`tbl`) is built before awaiting the client's progress confirmation, then consumed from afterward. `tbl` keyed by slot id only, with the count as the sole payload — no name, no durability snapshot. Post-await consumption trusted whatever currently occupied the slot. The await spans `recipe.duration or 3000` ms, during which `ox_inventory:swapItems` (a plain server callback) can replace the slot's contents.


## The wrong code

`modules/crafting/server.lua:167-189` — `tbl` was keyed by slot id with the count as the only payload:

```lua
tbl[slot.slot] = needs
-- ...
tbl[slot.slot] = slot.count
```

`modules/crafting/server.lua:201` — `lib.callback.await` yields for `recipe.duration or 3000` ms.

`modules/crafting/server.lua:208-251` — post-await consumption used whatever currently occupied the slot:

```lua
for slot, count in pairs(tbl) do
    local invSlot = left.items[slot]
    if not invSlot then return end

    if count < 1 then
        local item = Items(invSlot.name)
        local durability = invSlot.metadata.durability or 100
        -- ...consumes whatever item / durability is in the slot now
    else
        local removed = invSlot and Inventory.RemoveItem(left, invSlot.name, count, nil, slot)
        if not removed then return end
    end
end
```

`Inventory.RemoveItem` with a `slot` argument also doesn't validate that the slot has at least `count`; it calls `SetSlot(-count)` on whatever's there and reports `removed = count` regardless, so a slot with fewer items than required still yields a "successful" craft.

## Holes the trust pattern opens

- **Different item entirely.** Slot now holds something else; `RemoveItem(invSlot.name, ...)` consumes the substitute and the recipe still produces its output.
- **Same name, fewer items.** Slot has e.g. 2 instead of 5; `SetSlot(-5)` clears the 2 and reports success for 5.
- **Fractional consume, lower remaining durability.** The build-time eligibility check (`durability >= needs * 100`) is not re-evaluated; an item below the threshold gets consumed.
- **Fractional consume, item without durability.** `or 100` defaults a missing durability to 100, bypassing the original eligibility.
- **Fractional consume, time-based degrade with insufficient remaining percentage.** The percentage recompute from build time isn't repeated post-await.
- **Hash-order ingredient skip.** A `needs == 0` sentinel iterating before consumed ingredients ends the entire ingredient loop; consumed ingredients past that point are never reserved or removed.

## Fix

- Store the expected ingredient `{ name, count }` in `tbl` instead of just the count.
- Extract the durability/percentage eligibility into a helper used at both build and consume, so the math has one source of truth.
- Re-run that eligibility check against the current slot post-await; abort if it doesn't pass.
- Add a count check before slot-bound `RemoveItem` so a smaller stack can't masquerade as a successful removal.
- `Utils.LogExploit` on the name-mismatch path (the unambiguously-malicious one). Other abort paths stay silent because they could in principle stem from cross-resource state mutation. Drop flag omitted (= `false`); flip to `true` if you want auto-kick.

The redundant pre-loop existence check (`for name, needs in pairs(recipe.ingredients) do if Inventory.GetItemCount(left, name) < needs then return end end`) was removed; the per-slot loop is strictly stronger now and the total-count scan is dead weight.

## Behavior matrix

| Slot state at post-await | Pre-fix | Post-fix |
| --- | --- | --- |
| Unchanged (honest craft) | works | works |
| Slot empty | aborts | aborts |
| Slot now holds different item | consumes substitute, craft succeeds | aborts (logs as exploit) |
| Same name, fewer items than required | partial removal, craft succeeds | aborts |
| Fractional, lower remaining durability | consumes anyway | aborts |
| Fractional, item with no durability | defaults to 100, consumes | aborts |
| Fractional, time-based degrade insufficient % | consumes anyway | aborts |
| Recipe with `needs == 0` sentinel iterated before consumed ingredients | consumed ingredients silently skipped, free craft | sentinel skipped, consumed ingredients still reserved |


## Out of scope for this PR (worth follow-ups):
- `Inventory.RemoveItem` with a slot argument should validate `slotData.count >= count`; the band-aid is in the call site here.
- `craftItem` could lock ingredient slots in `activeSlots` for the duration of the await (matching `swapItems`' pattern), making post-await re-validation unnecessary.