### PR TITLE
add better fallbacks for openShop hook payload

### DIFF
--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -145,12 +145,12 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 			return
 		end
 
-		local shopType, shopId = shop.id:match('^(.-) (%d-)$')
+		local shopType, shopId = shop.id:match('^(.-) (%d+)$')
 
         local hookPayload = {
             source = source,
-            shopId = shopId,
-			shopType = shopType,
+            shopId = shopId or shop.id,
+			shopType = shopType or shop.id,
             label = shop.label,
             slots = shop.slots,
             items = shop.items,


### PR DESCRIPTION
This PR makes shopType and shopId fallback to the default `shop.id` in case the expected structure is not present (some shops defined in `data/shops.lua` present a shop.id that does not pass the regex match.

Also removed non-greedy repetition `%d-` from the matcher for more safe and intuitive behavior.