### PR TITLE
feat(bridge/qb): restore qb-core bridge

### DIFF
--- a/modules/bridge/qb/client.lua
+++ b/modules/bridge/qb/client.lua
@@ -1,0 +1,85 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+local Inventory = require 'modules.inventory.client'
+local Weapon = require 'modules.weapon.client'
+
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', client.onLogout)
+
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(data)
+    if source == '' or not PlayerData.loaded then return end
+
+    if (data.metadata.isdead or data.metadata.inlaststand) ~= PlayerData.dead then
+        PlayerData.dead = data.metadata.isdead or data.metadata.inlaststand
+        OnPlayerData('dead', PlayerData.dead)
+    end
+
+    local groups = PlayerData.groups
+
+    if not groups[data.job.name] or not groups[data.gang.name] or groups[data.job.name] ~= data.job.grade.level or groups[data.gang.name] ~= data.gang.grade.level then
+        PlayerData.groups = {
+            [data.job.name] = data.job.grade.level,
+            [data.gang.name] = data.gang.grade.level,
+        }
+
+        OnPlayerData('groups', PlayerData.groups)
+    end
+
+    if data.metadata.ishandcuffed then
+        PlayerData.cuffed = true
+        LocalPlayer.state:set('invBusy', true, false)
+        Weapon.Disarm()
+    elseif PlayerData.cuffed then
+        PlayerData.cuffed = false
+        LocalPlayer.state:set('invBusy', false, false)
+    end
+end)
+
+---@diagnostic disable-next-line: duplicate-set-field
+function client.setPlayerStatus(values)
+    for name, value in pairs(values) do
+        -- compatibility for ESX style values
+        if value > 100 or value < -100 then
+            value = value * 0.0001
+        end
+
+        if name == "hunger" then
+            TriggerServerEvent('consumables:server:addHunger', QBCore.Functions.GetPlayerData().metadata.hunger + value)
+        elseif name == "thirst" then
+            TriggerServerEvent('consumables:server:addThirst', QBCore.Functions.GetPlayerData().metadata.thirst + value)
+        elseif name == "stress" then
+            if value > 0 then
+                TriggerServerEvent('hud:server:GainStress', value)
+            else
+                value = math.abs(value)
+                TriggerServerEvent('hud:server:RelieveStress', value)
+            end
+        end
+    end
+end
+
+AddStateBagChangeHandler('inv_busy', ('player:%s'):format(cache.serverId), function(_, _, value)
+    LocalPlayer.state:set('invBusy', value, false)
+end)
+
+local function export(exportName, func)
+    AddEventHandler(('__cfx_export_%s_%s'):format(string.strsplit('.', exportName, 2)), function(setCB)
+        setCB(func or function()
+            error(("export '%s' is not supported when using ox_inventory"):format(exportName))
+        end)
+    end)
+end
+
+export('qb-inventory.HasItem', function(items, amount)
+    amount = amount or 1
+
+    if type(items) == 'table' then
+        for _, v in pairs(items) do
+            if Inventory.GetItemCount(v) < amount then
+                return false
+            end
+        end
+
+        return true
+    else
+        return Inventory.GetItemCount(items) >= amount
+    end
+end)

--- a/modules/bridge/qb/server.lua
+++ b/modules/bridge/qb/server.lua
@@ -1,0 +1,348 @@
+local Inventory = require 'modules.inventory.server'
+local Items = require 'modules.items.server'
+
+local QBCore
+
+AddEventHandler('QBCore:Server:OnPlayerUnload', server.playerDropped)
+
+AddEventHandler('QBCore:Server:OnJobUpdate', function(source, job)
+    local inventory = Inventory(source)
+    if not inventory then return end
+    inventory.player.groups[inventory.player.job] = nil
+    inventory.player.job = job.name
+    inventory.player.groups[job.name] = job.grade.level
+end)
+
+AddEventHandler('QBCore:Server:OnGangUpdate', function(source, gang)
+    local inventory = Inventory(source)
+    if not inventory then return end
+    inventory.player.groups[inventory.player.gang] = nil
+    inventory.player.gang = gang.name
+    inventory.player.groups[gang.name] = gang.grade.level
+end)
+
+AddEventHandler('onResourceStart', function(resource)
+    if resource ~= 'qb-weapons' and resource ~= 'qb-shops' then return end
+    StopResource(resource)
+end)
+
+---@param item SlotWithItem?
+---@return SlotWithItem?
+local function setItemCompatibilityProps(item)
+    if not item then return end
+
+    item.info = item.metadata
+    item.amount = item.count
+
+    return item
+end
+
+local function setupPlayer(Player)
+    Player.PlayerData.inventory = Player.PlayerData.items
+    Player.PlayerData.identifier = Player.PlayerData.citizenid
+    Player.PlayerData.name = ('%s %s'):format(Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname)
+    server.setPlayerInventory(Player.PlayerData)
+
+    Inventory.SetItem(Player.PlayerData.source, 'money', Player.PlayerData.money.cash)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "AddItem", function(item, amount, slot, info)
+        return Inventory.AddItem(Player.PlayerData.source, item, amount, info, slot)
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "RemoveItem", function(item, amount, slot)
+        return Inventory.RemoveItem(Player.PlayerData.source, item, amount, nil, slot)
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "GetItemBySlot", function(slot)
+        return setItemCompatibilityProps(Inventory.GetSlot(Player.PlayerData.source, slot))
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "GetItemByName", function(itemName)
+        return setItemCompatibilityProps(Inventory.GetSlotWithItem(Player.PlayerData.source, itemName))
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "GetItemsByName", function(itemName)
+        return setItemCompatibilityProps(Inventory.GetSlotsWithItem(Player.PlayerData.source, itemName))
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "ClearInventory", function(filterItems)
+        Inventory.Clear(Player.PlayerData.source, filterItems)
+    end)
+
+    QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "SetInventory", function()
+        -- ox_inventory's item structure is not compatible with qb-inventory's one so we don't support it
+        error(
+            'Player.Functions.SetInventory is unsupported for ox_inventory. Try ClearInventory, then add the desired items.')
+    end)
+end
+
+AddEventHandler('QBCore:Server:PlayerLoaded', setupPlayer)
+
+SetTimeout(500, function()
+    QBCore = exports['qb-core']:GetCoreObject()
+    server.GetPlayerFromId = QBCore.Functions.GetPlayer
+    local weapState = GetResourceState('qb-weapons')
+
+    if weapState ~= 'missing' and (weapState == 'started' or weapState == 'starting') then
+        StopResource('qb-weapons')
+    end
+
+    local shopState = GetResourceState('qb-shops')
+
+    if shopState ~= 'missing' and (shopState == 'started' or shopState == 'starting') then
+        StopResource('qb-shops')
+    end
+
+    for _, Player in pairs(QBCore.Functions.GetQBPlayers()) do setupPlayer(Player) end
+end)
+
+function server.UseItem(source, itemName, data)
+    local cb = QBCore.Functions.CanUseItem(itemName)
+    return cb and cb(source, data)
+end
+
+AddEventHandler('QBCore:Server:OnMoneyChange', function(src, account, amount, changeType)
+    if account ~= "cash" then return end
+
+    local item = Inventory.GetItem(src, 'money', nil, false)
+
+    if not item then return end
+
+    Inventory.SetItem(src, 'money',
+        changeType == "set" and amount or changeType == "remove" and item.count - amount or
+        changeType == "add" and item.count + amount)
+end)
+
+---@diagnostic disable-next-line: duplicate-set-field
+function server.setPlayerData(player)
+    local groups = {
+        [player.job.name] = player.job.grade.level,
+        [player.gang.name] = player.gang.grade.level
+    }
+
+    return {
+        source = player.source,
+        name = ('%s %s'):format(player.charinfo.firstname, player.charinfo.lastname),
+        groups = groups,
+        sex = player.charinfo.gender,
+        dateofbirth = player.charinfo.birthdate,
+        job = player.job.name,
+        gang = player.gang.name,
+    }
+end
+
+---@diagnostic disable-next-line: duplicate-set-field
+function server.syncInventory(inv)
+    local accounts = Inventory.GetAccountItemCounts(inv)
+
+    if accounts then
+        local player = server.GetPlayerFromId(inv.id)
+        player.Functions.SetPlayerData('items', inv.items)
+
+        if accounts.money and accounts.money ~= player.Functions.GetMoney('cash') then
+            player.Functions.SetMoney('cash', accounts.money, "Sync money with inventory")
+        end
+    end
+end
+
+---@diagnostic disable-next-line: duplicate-set-field
+function server.hasLicense(inv, license)
+    local player = server.GetPlayerFromId(inv.id)
+    return player and player.PlayerData.metadata.licences[license]
+end
+
+---@diagnostic disable-next-line: duplicate-set-field
+function server.buyLicense(inv, license)
+    local player = server.GetPlayerFromId(inv.id)
+    if not player then return end
+
+    if player.PlayerData.metadata.licences[license.name] then
+        return false, 'already_have'
+    elseif Inventory.GetItemCount(inv, 'money') < license.price then
+        return false, 'can_not_afford'
+    end
+
+    Inventory.RemoveItem(inv, 'money', license.price)
+    player.PlayerData.metadata.licences[license.name] = true
+    player.Functions.SetMetaData('licences', player.PlayerData.metadata.licences)
+
+    return true, 'have_purchased'
+end
+
+--- Takes traditional item data and updates it to support ox_inventory, i.e.
+--- ```
+--- Old: {1:{"name": "cola", "amount": 1, "label": "Cola", "slot": 1}, 2:{"name": "burger", "amount": 3, "label": "Burger", "slot": 2}}
+--- New: [{"slot":1,"name":"cola","count":1}, {"slot":2,"name":"burger","count":3}]
+---```
+---@diagnostic disable-next-line: duplicate-set-field
+function server.convertInventory(playerId, items)
+    if type(items) == 'table' then
+        local player = server.GetPlayerFromId(playerId)
+        local returnData, totalWeight = table.create(#items, 0), 0
+        local slot = 0
+
+        if player then
+            for name in pairs(server.accounts) do
+                local hasThis = false
+                for _, data in pairs(items) do
+                    if data.name == name then
+                        hasThis = true
+                    end
+                end
+
+                if not hasThis then
+                    local amount = player.Functions.GetMoney(name == 'money' and 'cash' or name)
+
+                    if amount then
+                        items[#items + 1] = { name = name, amount = amount }
+                    end
+                end
+            end
+        end
+
+        for _, data in pairs(items) do
+            local item = Items(data.name)
+
+            if item?.name then
+                local metadata, count = Items.Metadata(playerId, item, data.info, data.amount or data.count or 1)
+                local weight = Inventory.SlotWeight(item, { count = count, metadata = metadata })
+                totalWeight += weight
+                slot += 1
+                returnData[slot] = {
+                    name = item.name,
+                    label = item.label,
+                    weight = weight,
+                    slot = slot,
+                    count = count,
+                    description =
+                        item.description,
+                    metadata = metadata,
+                    stack = item.stack,
+                    close = item.close
+                }
+            end
+        end
+
+        return returnData, totalWeight
+    end
+end
+
+---@diagnostic disable-next-line: duplicate-set-field
+function server.isPlayerBoss(playerId)
+    local Player = QBCore.Functions.GetPlayer(playerId)
+
+    return Player.PlayerData.job.isboss or Player.PlayerData.gang.isboss
+end
+
+local function export(exportName, func)
+    AddEventHandler(('__cfx_export_%s_%s'):format(string.strsplit('.', exportName, 2)), function(setCB)
+        setCB(func or function()
+            error(("export '%s' is not supported when using ox_inventory"):format(exportName))
+        end)
+    end)
+end
+
+---Imagine if somebody who uses qb/qbox would PR these functions.
+export('qb-inventory.LoadInventory', function(playerId)
+    if Inventory(playerId) then return end
+
+    local player = QBCore.Functions.GetPlayer(playerId)
+
+    if player then
+        setupPlayer(player)
+
+        return Inventory(playerId).items
+    end
+end)
+
+export('qb-inventory.SaveInventory', function(playerId)
+    if type(playerId) ~= 'number' then
+        TypeError('playerId', 'number', type(playerId))
+    end
+
+    Inventory.Save(playerId)
+end)
+
+export('qb-inventory.SetInventory')
+export('qb-inventory.SetItemData')
+export('qb-inventory.UseItem')
+export('qb-inventory.GetSlotsByItem')
+export('qb-inventory.GetFirstSlotByItem')
+
+export('qb-inventory.GetItemBySlot', function(playerId, slotId)
+    return Inventory.GetSlot(playerId, slotId)
+end)
+
+export('qb-inventory.GetTotalWeight')
+
+export('qb-inventory.GetItemByName', function(playerId, itemName)
+    return Inventory.GetSlotWithItem(playerId, itemName)
+end)
+
+export('qb-inventory.GetItemsByName', function(playerId, itemName)
+    return Inventory.GetSlotsWithItem(playerId, itemName)
+end)
+
+export('qb-inventory.GetSlots')
+export('qb-inventory.GetItemCount')
+
+export('qb-inventory.CanAddItem', function(playerId, itemName, amount)
+    return (Inventory.CanCarryAmount(playerId, itemName) or 0) >= amount
+end)
+
+export('qb-inventory.ClearInventory', function(playerId, filter)
+    Inventory.Clear(playerId, filter)
+end)
+
+export('qb-inventory.CloseInventory', function(playerId, inventoryId)
+    local playerInventory = Inventory(playerId)
+
+    if not playerInventory then return end
+
+    local inventory = Inventory(playerInventory.open)
+
+    if inventory and (inventoryId == inventory.id or not inventoryId) then
+        playerInventory:closeInventory()
+    end
+end)
+
+export('qb-inventory.OpenInventory', function(playerId, invId, data)
+    local inventory = Inventory(invId)
+
+    if not inventory then return end
+
+    server.forceOpenInventory(playerId, inventory.type, inventory.id)
+end)
+
+export('qb-inventory.OpenInventoryById', function(playerId, targetId)
+    server.forceOpenInventory(playerId, 'player', targetId)
+end)
+
+export('qb-inventory.CreateShop')
+export('qb-inventory.OpenShop')
+
+export('qb-inventory.AddItem', function(invId, itemName, amount, slot, metadata)
+    return Inventory.AddItem(invId, itemName, amount, metadata, slot) and true
+end)
+
+export('qb-inventory.RemoveItem', function(invId, itemName, amount, slot)
+    return Inventory.RemoveItem(invId, itemName, amount, nil, slot) and true
+end)
+
+export('qb-inventory.HasItem', function(source, items, amount)
+    amount = amount or 1
+
+    local count = Inventory.Search(source, 'count', items)
+
+    if type(items) == 'table' and type(count) == 'table' then
+        for _, v in pairs(count) do
+            if v < amount then
+                return false
+            end
+        end
+
+        return true
+    end
+
+    return count >= amount
+end)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -411,7 +411,7 @@ function Inventory.SetSlot(inv, item, count, metadata, slot)
 	inv.items[slot] = currentSlot
 	inv.changed = true
 
-	return currentSlot
+	return currentSlot or true
 end
 
 CreateThread(function()

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -113,6 +113,103 @@ CreateThread(function()
 		end
 
 		Wait(500)
+
+	elseif shared.framework == 'qb' then
+		local QBCore = exports['qb-core']:GetCoreObject()
+		local items = QBCore.Shared.Items
+
+		if items and table.type(items) ~= 'empty' then
+			local dump = {}
+			local count = 0
+			local ignoreList = {
+				"weapon_",
+				"pistol_",
+				"pistol50_",
+				"revolver_",
+				"smg_",
+				"combatpdw_",
+				"shotgun_",
+				"rifle_",
+				"carbine_",
+				"gusenberg_",
+				"sniper_",
+				"snipermax_",
+				"tint_",
+				"_ammo"
+			}
+
+			local function checkIgnoredNames(name)
+				for i = 1, #ignoreList do
+					if string.find(name, ignoreList[i]) then
+						return true
+					end
+				end
+				return false
+			end
+
+			for k, item in pairs(items) do
+				if type(item) == 'table' then
+					if not item.name then item.name = k end
+
+					if not ItemList[item.name] and not checkIgnoredNames(item.name) then
+						item.close = item.shouldClose == nil and true or item.shouldClose
+						item.stack = not item.unique and true
+						item.description = item.description
+						item.weight = item.weight or 0
+						dump[k] = item
+						count += 1
+					end
+				end
+			end
+
+			if table.type(dump) ~= 'empty' then
+				local file = {string.strtrim(LoadResourceFile(shared.resource, 'data/items.lua'))}
+				file[1] = file[1]:gsub('}$', '')
+
+				---@todo separate into functions for reusability, properly handle nil values
+				local itemFormat = [[
+
+	[%q] = {
+		label = %q,
+		weight = %s,
+		stack = %s,
+		close = %s,
+		description = %q,
+		client = {
+			status = {
+				hunger = %s,
+				thirst = %s,
+				stress = %s
+			},
+			image = %q,
+		}
+	},
+]]
+
+				local fileSize = #file
+
+				for _, item in pairs(dump) do
+					if not ItemList[item.name] then
+						fileSize += 1
+
+						local itemStr = itemFormat:format(item.name, item.label, item.weight, item.stack, item.close, item.description or 'nil', item.hunger or 'nil', item.thirst or 'nil', item.stress or 'nil', item.image or 'nil')
+						itemStr = itemStr:gsub('[%s]-[%w]+ = "?nil"?,?', '')
+						itemStr = itemStr:gsub('[%s]-[%w]+ = %{[%s]+%},?', '')
+						itemStr = itemStr:gsub('[%s]-[%w]+ = %{[%s]+%},?', '')
+						file[fileSize] = itemStr
+						ItemList[item.name] = item
+					end
+				end
+
+				file[fileSize+1] = '}'
+
+				SaveResourceFile(shared.resource, 'data/items.lua', table.concat(file), -1)
+				shared.info(count, 'items have been copied from the QBCore.Shared.Items.')
+				shared.info('You should restart the resource to load the new items.')
+			end
+		end
+
+		Wait(500)
 	end
 
 	local count = 0

--- a/modules/mysql/server.lua
+++ b/modules/mysql/server.lua
@@ -32,6 +32,11 @@ Citizen.CreateThreadNow(function()
         playerColumn = 'charid'
         vehicleTable = 'nd_vehicles'
         vehicleColumn = 'id'
+    elseif shared.framework == 'qb' then
+        playerTable = 'players'
+        playerColumn = 'citizenid'
+        vehicleTable = 'player_vehicles'
+        vehicleColumn = 'plate'
     elseif shared.framework == 'qbx' then
         playerTable = 'players'
         playerColumn = 'citizenid'

--- a/modules/pefcl/server.lua
+++ b/modules/pefcl/server.lua
@@ -4,7 +4,9 @@
 
 	This isn't intended for use with frameworks with their own accounts,
 	use the proper pefcl-framework resources and ensure item/account syncing
-	works on your own.
+	works on your own. Note that qb uses "cash" but ox_inventory expects "money".
+
+	This is mostly here for ox_core.
 ]]
 
 local Inventory = require 'modules.inventory.server'

--- a/server.lua
+++ b/server.lua
@@ -491,7 +491,7 @@ lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, m
                 end
             elseif not item.weapon and server.UseItem then
                 inventory.usingItem = data
-                -- This is used to call an external useItem function, i.e. ESX.UseItem
+                -- This is used to call an external useItem function, i.e. ESX.UseItem / QBCore.Functions.CanUseItem
                 -- If an error is being thrown on item use there is no internal solution. We previously kept a list
                 -- of usable items which led to issues when restarting resources (for obvious reasons), but config
                 -- developers complained the inventory broke their items. Safely invoking registered item callbacks
@@ -594,7 +594,7 @@ RegisterCommand('convertinventory', function(source, args)
     local convert = arg and conversionScript[arg]
 
     if not convert then
-        return warn('Invalid conversion argument. Valid options: esx, esxproperty')
+        return warn('Invalid conversion argument. Valid options: esx, esxproperty, qb, linden')
     end
 
     CreateThread(convert)

--- a/setup/convert.lua
+++ b/setup/convert.lua
@@ -134,6 +134,220 @@ local function ConvertESX()
 	started = false
 end
 
+local function ConvertQB()
+	if started then
+		return warn('Data is already being converted, please wait..')
+	end
+
+	started = true
+	local users = MySQL.query.await('SELECT citizenid, inventory, money FROM players')
+	if not users then return end
+	local count = 0
+	local parameters = {}
+
+	for i = 1, #users do
+		local inventory, slot = {}, 0
+		local user = users[i]
+		local items = user.inventory and json.decode(user.inventory) or {}
+		local accounts = user.money and json.decode(user.money) or {}
+
+		for k, v in pairs(accounts) do
+			if type(v) == 'table' then break end
+			if k == 'cash' then k = 'money' end
+
+			if server.accounts[k] and Items(k) and v > 0 then
+				slot += 1
+				inventory[slot] = {slot=slot, name=k, count=v}
+			end
+		end
+
+		local shouldConvert = false
+
+		for _, v in pairs(items) do
+			if Items(v?.name) then
+				slot += 1
+				inventory[slot] = {slot=slot, name=v.name, count=v.amount, metadata = type(v.info) == 'table' and v.info or {}}
+				if v.type == "weapon" then
+					inventory[slot].metadata.durability = v.info.quality or 100
+					inventory[slot].metadata.ammo = v.info.ammo or 0
+					inventory[slot].metadata.components = {}
+					inventory[slot].metadata.serial = v.info.serie or GenerateSerial()
+					inventory[slot].metadata.quality = nil
+				end
+			end
+
+			shouldConvert = v.amount and true
+		end
+
+		if shouldConvert then
+			count += 1
+			parameters[count] = { 'UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode(inventory), user.citizenid } }
+		end
+	end
+
+	if count > 0 then
+	    Print(('Converting %s user inventories to new data format'):format(count))
+
+		if not MySQL.transaction.await(parameters) then
+			return Print('An error occurred while converting player inventories')
+		end
+		Wait(100)
+	else
+        print('literally why are you even running the convert command if you have no inventory data to convert? real 500iq move there')
+    end
+
+	local plates = MySQL.query.await('SELECT plate, citizenid FROM player_vehicles')
+
+	if plates then
+		for i = 1, #plates do
+			plates[plates[i].plate] = plates[i].citizenid
+		end
+
+		local oldqbdumpsterfire, trunk = pcall(MySQL.query.await, 'SELECT plate, items FROM trunkitems')
+
+		if oldqbdumpsterfire and trunk then
+			table.wipe(parameters)
+			count = 0
+			local vehicles = {}
+
+			for _, v in pairs(trunk) do
+				local owner = plates[v.plate]
+
+				if owner then
+					if not vehicles[owner] then
+						vehicles[owner] = {}
+					end
+
+					if not vehicles[owner][v.plate] then
+						local items = json.decode(v.items) or {}
+						local inventory, slot = {}, 0
+
+						for _, v in pairs(items) do
+							if Items(v?.name) then
+								slot += 1
+								inventory[slot] = {slot=slot, name=v.name, count=v.amount, metadata = type(v.info) == 'table' and v.info or {}}
+								if v.type == "weapon" then
+									inventory[slot].metadata.durability = v.info.quality or 100
+									inventory[slot].metadata.ammo = v.info.ammo or 0
+									inventory[slot].metadata.components = {}
+									inventory[slot].metadata.serial = v.info.serie or GenerateSerial()
+									inventory[slot].metadata.quality = nil
+								end
+							end
+						end
+
+						vehicles[owner][v.plate] = true
+						count += 1
+						parameters[count] = { 'UPDATE player_vehicles SET trunk = ? WHERE plate = ? AND citizenid = ?', { json.encode(inventory), v.plate, owner } }
+					end
+				end
+			end
+
+			Print(('Moving ^3%s^0 trunks to the player_vehicles table'):format(count))
+
+			if count > 0 then
+				if not MySQL.transaction.await(parameters) then
+					return Print('An error occurred while converting trunk inventories')
+				end
+
+				Wait(100)
+			end
+		end
+
+		local glovebox = oldqbdumpsterfire and MySQL.query.await('SELECT plate, items FROM gloveboxitems')
+
+		if glovebox then
+			table.wipe(parameters)
+			count = 0
+			local vehicles = {}
+
+			for _, v in pairs(glovebox) do
+				local owner = plates[v.plate]
+
+				if owner then
+					if not vehicles[owner] then
+						vehicles[owner] = {}
+					end
+
+					if not vehicles[owner][v.plate] then
+						local items = json.decode(v.items) or {}
+						local inventory, slot = {}, 0
+
+						for _, v in pairs(items) do
+							if Items(v?.name) then
+								slot += 1
+								inventory[slot] = {slot=slot, name=v.name, count=v.amount, metadata = type(v.info) == 'table' and v.info or {}}
+
+								if v.type == "weapon" then
+									inventory[slot].metadata.durability = v.info.quality or 100
+									inventory[slot].metadata.ammo = v.info.ammo or 0
+									inventory[slot].metadata.components = {}
+									inventory[slot].metadata.serial = v.info.serie or GenerateSerial()
+									inventory[slot].metadata.quality = nil
+								end
+							end
+						end
+
+						vehicles[owner][v.plate] = true
+						count += 1
+						parameters[count] = { 'UPDATE player_vehicles SET glovebox = ? WHERE plate = ? AND citizenid = ?', { json.encode(inventory), v.plate, owner } }
+					end
+				end
+			end
+
+			Print(('Moving ^3%s^0 gloveboxes to the player_vehicles table'):format(count))
+
+			if count > 0 then
+				if not MySQL.transaction.await(parameters) then
+					return Print('An error occurred while converting glovebox inventories')
+				end
+			end
+		end
+	end
+
+	local qbEvidence = MySQL.query.await("SELECT stash, items FROM stashitems WHERE stash LIKE '% | Drawer%'")
+
+	if qbEvidence then
+		table.wipe(parameters)
+		count = 0
+
+		---@type table<string, OxItem[]> maps stash name to inventory
+		local oxEvidence = {}
+
+		for i = 1, #qbEvidence do
+			local qbStash = qbEvidence[i]
+			local name = 'evidence-'..qbStash.stash:sub(12)
+			local items = server.convertInventory(nil, (qbStash.items and json.decode(qbStash.items) or {}))
+
+			--- evidence numbers can be shared between locations, so need to maintain map and merge.
+			if oxEvidence[name] then
+				for k = 1, #items do
+					oxEvidence[name][#oxEvidence[name]+1] = items[k]
+				end
+			else
+				oxEvidence[name] = items
+			end
+		end
+
+		for name, items in pairs(oxEvidence) do
+			count += 1
+			parameters[count] = { "INSERT INTO ox_inventory (owner, name, data) VALUES ('', ?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name), data = VALUES(data)", {
+				name, json.encode(items)
+			}}
+		end
+
+		Print(('Creating ^3%s^0 evidence lockers from ^3%s^0 lockers by merging duplicate locker numbers'):format(count, #qbEvidence))
+		if count > 0 then
+			if not MySQL.transaction.await(parameters) then
+				return Print('An error occurred while converting evidence lockers')
+			end
+		end
+	end
+
+	Print('Successfully converted user and vehicle inventories')
+	started = false
+end
+
 local function Convert_Old_ESX_Property()
 	if started then
 		return warn('Data is already being converted, please wait..')
@@ -201,5 +415,6 @@ end
 return {
 	linden = Upgrade,
 	esx = ConvertESX,
+	qb = ConvertQB,
 	esxproperty = Convert_Old_ESX_Property,
 }


### PR DESCRIPTION
## Why

`modules/bridge/qb` was removed in [34a3e9b](https://github.com/overextended/ox_inventory/commit/34a3e9b) ("fix: cure cancer", between v2.40.2 and v2.41.0). Stock `qb-core` servers (not `qbx_core`) lost upstream support. This PR brings the bridge back so `setr inventory:framework qb` boots ox_inventory against `qb-core` again.

Opened as a draft per CONTRIBUTING.md — happy to close if a re-add isn't wanted.

## What's restored

- **`modules/bridge/qb/{client,server}.lua`** — restored verbatim from `34a3e9b~1`.
- **`modules/mysql/server.lua`** — qb branch (`players.citizenid`, `player_vehicles.plate`).
- **`modules/items/server.lua`** — `QBCore.Shared.Items` auto-import into `data/items.lua`.
- **`setup/convert.lua`** — `ConvertQB` migration (player inventory/money, trunks, gloveboxes, stash items, evidence drawers).
- **`server.lua`** — `qb` re-added to the `convertinventory` valid-args list and `UseItem` comment.
- **`modules/pefcl/server.lua`** — qb cash/money mismatch note.

All qb bridge bugfixes that landed before the deletion are preserved: #1284, #1285, #1411, #1587, #1608, #1711.

## Bugs fixed in this PR

1. **`onResourceStart` never stopped `qb-weapons` / `qb-shops`** — pre-existing logic used `or` instead of `and`, so the guard short-circuited and the resources kept running. Fixed in the restored handler.
2. **`Inventory.RemoveItem` errored when a slot was fully emptied** — `Inventory.SetSlot` returns `nil` after clearing a slot (e.g. removing the last `pressurewash` in slot 1). The error-checking added in [067e89f8](https://github.com/overextended/ox_inventory/commit/067e89f8) treated that `nil` as failure and threw `Failed to remove 1x <item> from inventory-<id>:slot-<n> (nil).` Fix: `SetSlot` now returns `true` when it intentionally empties a slot, so the success path stays truthy.

## Contract check

The restored bridge still matches the current ox_inventory surface:

| Surface | Status |
|---|---|
| `server.hasGroup` numeric-rank specs (#65) | qb writes via `grade.level` — compatible |
| `server.syncInventory(inv)` | shape unchanged, reads `inv.id` |
| `server.setPlayerData` return shape | additive (`job` / `gang`) |
| `Inventory.{GetItem,AddItem,RemoveItem,SetItem,GetSlot*,Clear,Save,Search,CanCarryAmount,SlotWeight,GetAccountItemCounts}` | signatures match |
| `Items.Metadata` | signature matches |
| `lib.load('modules.bridge.qb.server')` | works unmodified |

## How to test

- [ ] Boot FiveM server with `setr inventory:framework qb` and latest `qb-core` — no errors at `init.lua`.
- [ ] Connect a character — F2 opens inventory, slots and weight defaults apply.
- [ ] `/setmoney cash 500` → `money` item shows 500. Drop it → cash decreases.
- [ ] `/setjob police 3` → group-restricted shop accessible. Demote to `police 1` → denied.
- [ ] Use a registered item → `QBCore.Functions.CanUseItem` callback fires.
- [ ] Equip a weapon item; `qb-weapons` auto-stops on boot.
- [ ] `/cuff` and last-stand state → inventory blocked (#1284 / #1285 behaviour).
- [ ] License purchase at PD desk → `PlayerData.metadata.licences` updates; repeat returns `already_have`.
- [ ] Remove an item from `data/items.lua`, restart → re-imported from `QBCore.Shared.Items`.
- [ ] `exports.ox_inventory['qb-inventory.HasItem'](src, 'bread', 1)` → `true`.
- [ ] `convertinventory qb` against a qb-core DB snapshot → ox-format JSON for players, trunks, gloveboxes, evidence drawers.
- [ ] Remove the **last** unit of an item from a slot → no `SCRIPT ERROR` (regression check for the SetSlot fix).

## Known race

`setupPlayer` from `PlayerLoaded` can fire before the `SetTimeout(500, …)` that assigns `QBCore`. The same timeout also scans `GetQBPlayers()` so existing players are picked up, but a connection inside that window can hit a nil `QBCore`. Pre-existing behaviour from the original bridge — happy to tighten with a `lib.waitFor`-style guard if preferred.
