### PR TITLE
Hotfix: incorrect variable name in updateWeapon function

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2605,12 +2605,12 @@ local function updateWeapon(source, action, value, slot, specialAmmo)
 			elseif action == 'throw' then
 				if not Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot) then return end
 			elseif action == 'component' then
-				if type == 'number' then
+				if vtype == 'number' then
 					if not Inventory.AddItem(inventory, weapon.metadata.components[value], 1) then return false end
 
 					table.remove(weapon.metadata.components, value)
 					weapon.weight = Inventory.SlotWeight(item, weapon)
-				elseif type == 'string' then
+				elseif vtype == 'string' then
 					local component = inventory.items[tonumber(value)]
 
 					if not Inventory.RemoveItem(inventory, component.name, 1) then return false end


### PR DESCRIPTION
This PR corrects an oversight introduced in https://github.com/overextended/ox_inventory/commit/0f43d658e5d3529df85f9891aa683f2489d7a2c1 where the `type` variable was renamed to `vtype` for better naming convention as it overwrote the base lua type function.

This oversight leads to weapon metadata not being updated correctly which in turn leads to components not being saved to the weapon in effect reverting the changes made to it when unequipping/reequipping the weapon.