### PR TITLE
fix(client): opening a glovebox in a moving vehicle

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -294,7 +294,7 @@ function client.openInventory(inv, data)
         }
     })
 
-    if inv and not currentInventory.coords and inv ~= 'container' then
+    if inv and not currentInventory.coords and inv ~= 'container' and inv ~= 'glovebox' then
         currentInventory.coords = GetEntityCoords(playerPed)
     end
 


### PR DESCRIPTION
When opening a glovebox, ox was checking coordinates, leading to a "inventory_lost_access" error when the vehicle was moving.