### PR TITLE
fix(server): commit swapItems atomically so a yielding hook cannot dupe

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1636,6 +1636,7 @@ local function dropItem(source, playerInventory, fromData, data)
 	})
 
 	if not hooks.success then return end
+	if Inventories[playerInventory.id] ~= playerInventory then hooks.success = false return end
 
     fromData.count -= data.count
     fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
@@ -1800,7 +1801,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 						local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 						if not hooks.success then return end
-						if not partiesPresent() then return end
+						if not partiesPresent() then hooks.success = false return end
 
 						if containerItem then
 							local toContainer = toInventory.type == 'container'
@@ -1836,7 +1837,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 					if not hooks.success then return end
-					if not partiesPresent() then return end
+					if not partiesPresent() then hooks.success = false return end
 
 					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
 				end
@@ -1859,7 +1860,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 					if not hooks.success then return end
-					if not partiesPresent() then return end
+					if not partiesPresent() then hooks.success = false return end
 
 					fromData.count, toData.count = fromCount, toCount
 					toData.weight = toSlotWeight
@@ -1900,7 +1901,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 					if not hooks.success then return end
-					if not partiesPresent() then return end
+					if not partiesPresent() then hooks.success = false return end
 
 					if not sameInventory then
 						local toContainer = toInventory.type == 'container'

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1730,6 +1730,12 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 	local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
 	local toData = toInventory.items[data.toSlot]
 
+	local function partiesPresent()
+		return Inventories[playerInventory.id] == playerInventory
+			and Inventories[fromInventory.id] == fromInventory
+			and Inventories[toInventory.id] == toInventory
+	end
+
 	if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
 		local group, rank = server.hasGroup(playerInventory, shared.police)
 
@@ -1794,6 +1800,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 						local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 						if not hooks.success then return end
+						if not partiesPresent() then return end
 
 						if containerItem then
 							local toContainer = toInventory.type == 'container'
@@ -1829,15 +1836,21 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 					if not hooks.success then return end
+					if not partiesPresent() then return end
 
 					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
 				end
 
 			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
-				-- Stack items
-				toData.count += data.count
-				fromData.count -= data.count
+				local originalFromCount, originalToCount = fromData.count, toData.count
+				local fromCount, toCount = originalFromCount - data.count, originalToCount + data.count
+				local originalFromWeight = fromData.weight
+
+				fromData.count, toData.count = fromCount, toCount
+				local fromSlotWeight = Inventory.SlotWeight(Items(fromData.name), fromData)
 				local toSlotWeight = Inventory.SlotWeight(Items(toData.name), toData)
+				fromData.count, toData.count = originalFromCount, originalToCount
+
 				local totalWeight = toInventory.weight - toData.weight + toSlotWeight
 
 				if fromInventory.type == 'container' or sameInventory or totalWeight <= toInventory.maxWeight then
@@ -1845,18 +1858,14 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
-					if not hooks.success then
-						toData.count -= data.count
-						fromData.count += data.count
+					if not hooks.success then return end
+					if not partiesPresent() then return end
 
-						return
-					end
-
-					local fromSlotWeight = Inventory.SlotWeight(Items(fromData.name), fromData)
+					fromData.count, toData.count = fromCount, toCount
 					toData.weight = toSlotWeight
 
 					if not sameInventory then
-						fromInventory.weight = fromInventory.weight - fromData.weight + fromSlotWeight
+						fromInventory.weight = fromInventory.weight - originalFromWeight + fromSlotWeight
 						toInventory.weight = totalWeight
 
 						if container then
@@ -1876,8 +1885,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 					fromData.weight = fromSlotWeight
 				else
-					toData.count -= data.count
-					fromData.count += data.count
 					return false, 'cannot_carry'
 				end
 			elseif data.count <= fromData.count then
@@ -1893,6 +1900,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					local hooks <close> = TriggerEventHooks('swapItems', hookPayload)
 
 					if not hooks.success then return end
+					if not partiesPresent() then return end
 
 					if not sameInventory then
 						local toContainer = toInventory.type == 'container'

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1731,6 +1731,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 	local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
 	local toData = toInventory.items[data.toSlot]
 
+	---@return boolean
 	local function partiesPresent()
 		return Inventories[playerInventory.id] == playerInventory
 			and Inventories[fromInventory.id] == fromInventory


### PR DESCRIPTION
## Background

#1950 stopped the actively-exploited duplication (transfer an item into a
persistent inventory, then disconnect or relog via multichar mid-transfer) by
deferring the post-event `Wait` off the swap's critical section and force-saving
a disconnecting player. That closes the case where **no** `swapItems` hook is
registered.

It does **not** fully close the case where a registered `swapItems` hook
**yields**, which is a documented, valid use (e.g. an async DB read for
validation). A hook that yields re-opens the same disconnect window, and worse,
unbounded in length. This PR closes that window structurally so duplication is
impossible regardless of whether a hook yields.


## The fix

Three changes that together make the commit atomic with respect to any
disconnect, for any hook behaviour:

1. **Stack branch becomes compute-then-commit.** It no longer mutates the live
   counts before the hook. It computes the resulting slot weights using a
   temporary count assignment that is restored before the hook can yield, runs
   the hook, then applies the counts in a single block with no yield until the
   `changed` flags are set. The two manual count-rollbacks are gone because
   nothing is mutated before the commit. The `swap` and `move` branches already
   ran the hook before mutating, so they keep their structure.

2. **Post-hook presence re-check (`partiesPresent`).** After every
   `swapItems` hook (four sites), and in `newdrop`/`dropItem` (see below):

   ```lua
   local function partiesPresent()
       return Inventories[playerInventory.id] == playerInventory
           and Inventories[fromInventory.id] == fromInventory
           and Inventories[toInventory.id] == toInventory
   end
   ...
   if not hooks.success then return end
   if not partiesPresent() then hooks.success = false return end
   ```

   This is the load-bearing piece. Compute-then-commit alone is **not** enough:
   after the hook, the swap would still commit the container side for a player
   already removed and saved in pre-state during the yield, duplicating a
   deposit. The re-check aborts the commit if any party (player, source, or
   destination inventory) was removed during the hook yield. It compares against
   the raw `Inventories` registry by identity, so a reconnect that re-registers
   a new object under the same id is correctly treated as absent. It sets
   `hooks.success = false` so post-event listeners are not told a non-committed
   swap succeeded (matching the existing idiom at `dropItem`).

3. **`newdrop` / `dropItem` gets the same guard.** The `toType == 'newdrop'`
   path returns `dropItem(...)` directly from `swapItems`. `dropItem` runs its
   own `swapItems` hook and then decrements the source and creates the world
   drop. Without a re-check, a disconnect during that hook saved the player with
   the full stack while the drop was created for another player to pick up, the
   same dupe. A presence re-check after the hook closes it.

After this, a disconnect during a hook yield means nothing was mutated, the
player is saved clean, and the swap aborts. With no hook, the swap is fully
synchronous and nothing can interleave. Neither deposit nor withdrawal can dupe
or void, no matter how long a hook yields.


## Behaviour change to note

In the `stack` branch, a `swapItems` hook now sees the **pre-swap** counts in
`payload.fromSlot.count` / `payload.toSlot.count` instead of the
already-decremented values. This makes the `stack` branch consistent with the
`swap` and `move` branches, which already pass pre-mutation counts. Hooks that
use `payload.count` (the delta, unchanged) are unaffected.

## Out of scope (follow-ups)

The same "mutate or commit after a yielding hook" shape exists in other hook
callers that this PR does not touch: `giveItem`, `craftItem` (which awaits a
client callback, a long yield), `buyItem`, and `usingItem`. They should get the
same presence re-check in a follow-up. Until then, the force-save of a
disconnecting player from #1950 (`inv.changed or inv.player` in
`Inventory.Remove`) is worth keeping as a cheap backstop for those paths. It is
no longer load-bearing for `swapItems`, but it provides partial protection for
the un-audited callers at the cost of one save per disconnect. Once those are
hardened it can revert to `inv.changed`.

Separately, there is a pre-existing concurrency gap unrelated to the disconnect
race: `Inventory.AddItem` / `Inventory.RemoveItem` and other name-based mutators
do not honour the per-slot locks that `swapItems` takes. If such a mutator runs
on an involved inventory during a yielding hook, the swap's post-hook weight
assignment (a pre-hook snapshot) can clobber it, desyncing `inventory.weight`
and bypassing `maxWeight`; and if it clears the swapped slot, `SwapSlots` can
operate on stale or nil slot data. The weight-after-hook assignment is unchanged
from upstream, so this is not introduced here. The proper fix is to make those
mutators lock-aware (or take an inventory-level lock), which is a separate
change.


