### PR TITLE
fix(client): redefine data table by deepcloning it

### DIFF
--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -172,7 +172,7 @@ local function refreshShops()
                                     distance = target.distance
                                 }
                             }),
-							blip = blip and createBlip(blip, target.coords)
+							blip = blip and createBlip(blip, target.loc)
 						}
 					end
 

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -163,6 +163,8 @@ end
 ---@param options? OxTargetOption[]
 ---@return number
 function Utils.CreateBoxZone(data, options)
+    local data = lib.table.deepclone(data)
+
     if data.length then
         local height = math.abs(data.maxZ - data.minZ)
         local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2


### PR DESCRIPTION
**Issue:**
When the shops are loaded in the resource setup stage, the data is refferenced from the loaded config data table. When applying this operation repeatedly(for example changing player group data) the table data gets modified and leads into unwanted behavior - the shops become unavailable and in rare cases can lead into resource crashes.

**Fix:**
Deepclone the data table to prevent the data becoming malformed.