### PR TITLE
fix(inventory): return empty slot when no matching stack exists

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2214,10 +2214,12 @@ function Inventory.GetSlotForItem(inv, itemName, metadata)
 	for i = 1, inventory.slots do
 		local slotData = items[i]
 
+		if not slotData and not emptySlot then
+			emptySlot = i
+		end
+
 		if item.stack and slotData and slotData.name == item.name and table.matches(slotData.metadata, metadata) then
 			return i
-		elseif not item.stack and not slotData and not emptySlot then
-			emptySlot = i
 		end
 	end
 


### PR DESCRIPTION
### Fix `GetSlotForItem` Returning `nil` for Missing Stackable Items

Fixes an issue where `Inventory.GetSlotForItem` could return `nil` for stackable items when the player did not already possess the item.

Previously, the function only tracked empty slots for non-stackable items. As a result, when a player's inventory contained no items, the function was unable to resolve a valid slot for stackable items and returned `nil`, preventing items from being given to the player despite available inventory space.

Interestingly, the previous implementation appeared to work correctly once the player already had at least one item in their inventory, making the issue most noticeable on empty inventories.

The logic has been updated to always track the first available empty slot while still prioritizing existing matching stacks for stackable items. If no matching stack is found, the function now correctly returns the first empty slot instead of `nil`.

**Related Issue:**
This change addresses the behavior reported in issue #1943.
