### PR TITLE
Fixes the double restart after a client-side code update

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -66,6 +66,7 @@ function server.setPlayerInventory(player, data)
         inv.player.ped = GetPlayerPed(player.source)
 
         if server.syncInventory then server.syncInventory(inv) end
+        Wait(250) -- Wait to load the client part after update to not cause (player inventory has not loaded)
         TriggerClientEvent('ox_inventory:setPlayerInventory', player.source, Inventory.Drops, inventory, totalWeight,
             inv.player)
     end


### PR DESCRIPTION
So when I restart ox_inventory and I have updated something in the client part, when it's cached, the inventory is printing return shared.info('cannot open inventory', '(player inventory has not loaded)') because PlayerData.loaded is false and I need to restart it again. But when I added the 250ms wait, it works fine with one restart.
I don't know if this is the correct way and if it's done on purpose — either way, this is why I made this pull request.

<img width="1914" height="120" alt="Screenshot 2026-06-18 015101" src="https://github.com/user-attachments/assets/c66cdb45-903c-44c0-9c3a-005009e3ebf8" />
