### PR TITLE
Fix parameter name in defaultGetPlayerName function

### DIFF
--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -239,7 +239,7 @@ function Utils.blurOut()
     TriggerScreenblurFadeOut(250)
 end
 
----@param serverID number
+---@param serverId number
 ---@return string
 local function defaultGetPlayerName(serverId)
     local playerId = GetPlayerFromServerId(serverId)


### PR DESCRIPTION
Fix a typo that causes an "Undefined param" warning.