### PR TITLE
fix(server): yield while waiting for player ped

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -63,9 +63,13 @@ function server.setPlayerInventory(player, data)
 
     if inv then
         inv.player = server.setPlayerData(player)
-
+        
         repeat
             inv.player.ped = GetPlayerPed(player.source)
+        
+            if inv.player.ped == 0 then
+                Wait(0)
+            end
         until inv.player.ped ~= 0
 
         if server.syncInventory then server.syncInventory(inv) end


### PR DESCRIPTION
## Description

Prevents the server thread from being blocked while `setPlayerInventory` waits for the player's ped to become available.

The current loop repeatedly calls `GetPlayerPed` without yielding:

```lua
repeat
    inv.player.ped = GetPlayerPed(player.source)
until inv.player.ped ~= 0
```

On a live OneSync server with more than 60 concurrent players, the ped occasionally took longer to become available. During testing, the loop performed 431,460 iterations over 1,290 ms and caused a corresponding server thread hitch warning of 1,305 ms.

This change adds `Wait(0)` only when the ped is unavailable, allowing the current coroutine to yield until the next server tick.

The existing behaviour is preserved: the inventory still waits for the ped and continues loading normally as soon as it becomes available.

## Testing

Tested on a live OneSync server with more than 60 concurrent players.

### Before

- Ped wait: 1,290 ms
- Loop iterations: 431,460
- Server thread hitch: 1,305 ms

### After

- The player inventory loaded normally.
- Inventory data continued to be synchronized correctly.
- The corresponding server thread hitch warnings stopped occurring.
